### PR TITLE
Adding Pytest Instructions to READme

### DIFF
--- a/README.md
+++ b/README.md
@@ -98,7 +98,7 @@ Monitor GPU health across your entire OpenShift cluster:
 - `yq` for YAML processing
 - **Prometheus/Thanos** deployed for metrics collection
 - **DCGM exporter** for GPU monitoring (optional but recommended)
-- [Slack Webhook URL](https://api.slack.com/messaging/webhooks) (for alerting)
+- Slack Webhook URL for optional alerting ([How to create a Webhook for your Slack Workspace](https://api.slack.com/messaging/webhooks))
 
 ---
 
@@ -221,24 +221,56 @@ To generate a report:
 
 ## Local Development via Port-Forwarding
 
-In order to develop locally faster on the MCP/UI you can leverage port-forwarding to llamastack, model and thanos. 
+In order to develop locally faster on the MCP/UI you can leverage port-forwarding to Llamastack, llm-service and Thanos. `scripts/local-dev.sh` port-forwards these services and locally starts the mcp and ui servers for local testing and devlopment.
+
 Pre-requisites: you have a deployment on the cluster already.
 
-1. Port-Forward to llamastack, model & thanos:
-    1. `oc port-forward pod/llamastack 8321`
-    1. `oc port-forward pod/model 8080`
-    1. `oc port-forward pod/thanos-querier 9090 -n openshift-monitoring`
-1. If testing mcp, navigate to mcp/ and run -- `python3 -m uvicorn mcp:app --host 0.0.0.0 --port 8000 --reload` and you can use curl commands to test the apis
-   1. Configure **MODEL_CONFIG** env variable `export MODEL_CONFIG='{"meta-llama/Llama-3.2-3B-Instruct":{"external":false,"requiresApiKey":false,"serviceName":"llama-3-2-3b-instruct"},"openai/gpt-4o-mini":{"external":true,"requiresApiKey":true,"serviceName":null,"provider":"openai","apiUrl":"https://api.openai.com/v1/chat/completions","modelName":"gpt-4o-mini", "cost": {"prompt_rate": 0.00000015, "output_rate": 0.0000006}}}'`
-   2. This may change, see `deploy/helm/Makefile` for the latest version. 
-1. And then to test the ui, navigate to ui/ and run -- `streamlit run ui.py`
+1. Modify the `LLM_NAMESPACE` variable in `scripts/local-dev.sh` or export `LLM_NAMESPACE` as an environmental variable.
+2. Run the development script:
+```
+./scripts/local-dev.sh
+```
 
-### Macos weasyprint install
+### Macos Weasyprint Install
 
 In order to run the mcp locally you'll need to install weasyprint:
 1. Install via brew `brew install weasyprint`
 2. Ensure installation `weasyprint --version`
 3. Set **DYLD_FALLBACK_LIBRARY_PATH** `export DYLD_FALLBACK_LIBRARY_PATH=/opt/homebrew/lib:$DYLD_FALLBACK_LIBRARY_PATH`
+
+## Running Tests with Pytest
+
+The test suite is located in the `tests/` directory, with the tests for each service in their respective directories.
+
+1. Create a virtual environment and install the project with dev dependencies in the base directory. 
+
+```bash
+# Create virtual environment
+python -m venv venv
+
+# Activate virtual environment
+source venv/bin/activate
+
+# Install development dependencies (includes formatting tools)
+pip install -e ".[dev]"
+```
+
+This will take the dependencies listed in `pyproject.toml` and install them.
+
+2. Use the `pytest` command go run all tests
+
+```bash
+# Run all tests with verbose output and coverage
+pytest -v --cov=metric_ui --cov-report=html --cov-report=term
+
+# Run only MCP tests
+pytest -v tests/mcp/
+
+# Run specific test file
+pytest -v tests/mcp/test_api_endpoints.py
+```
+
+To view a detailed coverage report after generating, open `htmlcov/index.html`.
 
 ---
 


### PR DESCRIPTION
## Changes

- Updated READme to contain instructions to run `pytest`
- Added instructions on how to use the `local-dev.sh` script

## Screenshots
<img width="883" height="923" alt="Screenshot 2025-07-22 at 3 03 57 PM" src="https://github.com/user-attachments/assets/a45dfbeb-0dba-4953-83a1-e6509207a2f1" />

## Checklist

- [ ] Verify on the cluster
- [x] Add screenshots (if applicable)
- [x] Update readme (if applicable)