### PR TITLE
Enhance Prompt Reliability and Reduce Hallucination in Metric Summarizer

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -178,3 +178,6 @@ cython_debug/
 
 # macOS
 .DS_Store
+
+# log files
+src/api/log.txt

--- a/scripts/local-dev.sh
+++ b/scripts/local-dev.sh
@@ -112,7 +112,7 @@ start_local_services() {
     
     # Start MCP service
 echo -e "${BLUE}🔧 Starting MCP backend...${NC}"
-(cd src/api && python3 -m uvicorn metrics_api:app --host 0.0.0.0 --port $MCP_PORT --reload) &
+(cd src/api && python3 -m uvicorn metrics_api:app --host 0.0.0.0 --port $MCP_PORT --reload > log.txt) &
     MCP_PID=$!
     
     # Wait for MCP to start


### PR DESCRIPTION
## Changes

Prompts are enhanced to improve the responses and reduce hallucination for the internal model Llama 3.2-8b-instruct.

Tested 20 times for vLLM Metric Summarizer and OpenShift Metrics successfully with the internal model as well as the external models and the responses were good.

Note that this PR won't eliminate the hallucinations totally, and if you find such issues we can enhance the prompts further in a follow up PR if needed.

Note:vA separate PR will be submitted to validate the model responses and clean up any unwanted information.

## Checklist

- [X ] Verify on the cluster
- [ X] Update tests if applicable and run `pytest`
- [ ] Add screenshots (if applicable)
- [ ] Update readme (if applicable)