### PR TITLE
fixed issue with local setup - namespace was not being used

### DIFF
--- a/scripts/local-dev.sh
+++ b/scripts/local-dev.sh
@@ -97,10 +97,10 @@ function set_model_config() {
     # Find metrics-api-app deployment
     # MODEL_CONFIG=$(oc get deploy 'metrics-api-app' -n"$LLM_NAMESPACE" -o json -o jsonpath='{.spec.template.spec.containers..env}' | jq '.[] | select(.name == "MODEL_CONFIG") | .value')
 
-    METRIC_API_DEPLOYMENT=$(oc get deploy "$METRIC_API_APP" -n"$LLM_NAMESPACE")
+    METRIC_API_DEPLOYMENT=$(oc get deploy "$METRIC_API_APP" -n "$LLM_NAMESPACE")
     if [ -n "$METRIC_API_DEPLOYMENT" ]; then
         echo -e "${GREEN}✅ Found [$METRIC_API_APP] deployment: $METRIC_API_DEPLOYMENT${NC}"
-        export $(oc set env deployment/$METRIC_API_APP --list | grep MODEL_CONFIG)
+        export $(oc set env deployment/$METRIC_API_APP --list  -n "$LLM_NAMESPACE" | grep MODEL_CONFIG)
         if [ -n "$MODEL_CONFIG" ]; then
           echo -e "${GREEN}✅   MODEL_CONFIG set to: $MODEL_CONFIG${NC}"
         else


### PR DESCRIPTION
## Changes

Added an explicit namespace when trying to retrieve environment from `metrics-api-app` deployment. This namespace was missing earlier and caused error when the script was run in a new shell.

## Checklist

- [x] Tested the local setup by running the script locally
- [ ] Verify on the cluster
- [ ] Update tests if applicable and run `pytest`
- [x] Add screenshots (if applicable)
- [ ] Update readme (if applicable)


<img width="1499" height="1184" alt="Screenshot 2025-08-08 at 12 26 57 PM" src="https://github.com/user-attachments/assets/a474ae8a-a2c6-4048-8edf-84316bff0910" />
