### PR TITLE
Using correct branch for checkout + fixed workflow for automatic run + fixed dockerfile issue

### DIFF
--- a/.github/workflows/build-and-push.yml
+++ b/.github/workflows/build-and-push.yml
@@ -1,8 +1,7 @@
 name: Build and push image
 
 on:
-  pull_request:
-    types: [closed]
+  push:
     branches:
       - main
       - dev
@@ -20,7 +19,7 @@ jobs:
   semantic-version:
     name: Generate semantic version
     runs-on: ubuntu-latest
-    if: github.event.pull_request.merged == true || github.event_name == 'workflow_dispatch'
+    if: github.event_name == 'push' || github.event_name == 'workflow_dispatch'
     outputs:
       version: ${{ steps.version.outputs.version }}
     steps:
@@ -189,7 +188,7 @@ jobs:
     name: Update versions in Helm charts and Makefile
     runs-on: ubuntu-latest
     needs: [semantic-version, build-image]
-    if: (github.event_name == 'pull_request' && github.event.pull_request.merged == true) || github.event_name == 'workflow_dispatch'
+    if: github.event_name == 'push' || github.event_name == 'workflow_dispatch'
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -33,6 +33,8 @@ jobs:
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event.workflow_run.head_ref || github.ref }}
 
       - name: Install OpenShift CLI
         uses: redhat-actions/openshift-tools-installer@v1

--- a/Makefile
+++ b/Makefile
@@ -201,7 +201,7 @@ build-mcp-server:
 	@$(BUILD_TOOL) buildx build --platform $(PLATFORM) \
 		-f src/mcp_server/Dockerfile \
 		-t $(MCP_SERVER_IMAGE):$(VERSION) \
-		.
+		src
 	@echo "✅ mcp-server image built: $(MCP_SERVER_IMAGE):$(VERSION)"
 
 .PHONY: push

--- a/src/mcp_server/Dockerfile
+++ b/src/mcp_server/Dockerfile
@@ -3,13 +3,13 @@ FROM registry.access.redhat.com/ubi9/python-312:latest
 WORKDIR /app
 
 # Copy and install Python dependencies via pip using requirements.txt
-COPY src/mcp_server/requirements.txt /app/requirements.txt
+COPY mcp_server/requirements.txt /app/requirements.txt
 RUN python -m pip install --no-cache-dir --upgrade pip \
     && python -m pip install --no-cache-dir -r /app/requirements.txt
 
 # Copy source code
-COPY src/core /app/core
-COPY src/mcp_server /app/mcp_server
+COPY core /app/core
+COPY mcp_server /app/mcp_server
 
 ENV PYTHONPATH=/app
 EXPOSE 8085


### PR DESCRIPTION
## Changes

Fix GitHub Actions workflow triggers and Docker build context for MCP server deployment

Changes

  - The current workflow was always checkout out the default (`main`) branch:
    - Added proper branch checkout reference in deploy workflow to ensure correct branch deployment
  - In automatic `build and push` workflow runs, the **Username and password required** [error](https://github.com/rh-ai-kickstart/openshift-ai-observability-summarizer/actions/runs/17128923826/job/48587588819#step:4:11) is encountered but not in a manual run:
    - Our workflow used `pull_request: types: [closed]` trigger, but GitHub doesn't provide access to secrets for pull request events due to security restrictions
    - Updated workflow conditions to use `push` events instead of merged PR checks
    - Changed build trigger from `pull_request.closed` to `push` events on main/dev branches for immediate builds
  - `/src/mcp_server: not found` [error](https://github.com/rh-ai-kickstart/openshift-ai-observability-summarizer/actions/runs/17129099823/job/48588216063#step:5:229)
    - Fixed Makefile Docker build context from . to src directory
    - Updated Dockerfile COPY paths to work with new build context (removed src/ prefix from paths)
    - Ensures proper file structure for MCP server container builds
    - Tested locally by running `make build-mcp-server`

  These changes should resolve workflow execution issues and ensure the MCP server builds correctly with the proper file paths and deployment triggers.

## Checklist

- [ ] Verify on the cluster
- [ ] Update tests if applicable and run `pytest`
- [ ] Add screenshots (if applicable)
- [ ] Update readme (if applicable)