### PR TITLE
APPENG-3414: changes regarding use of a common/existing model

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -436,10 +436,22 @@ list-models: depend
 .PHONY: install-local
 install-local:
 	@echo "🚀 Setting up local development environment..."
+	@if [ -z "$(NAMESPACE)" ]; then \
+		echo "❌ Error: NAMESPACE parameter is required"; \
+		echo "Usage: make install-local NAMESPACE=your-namespace"; \
+		echo "Optional: make install-local NAMESPACE=default-ns MODEL_NAMESPACE=model-ns"; \
+		exit 1; \
+	fi
+	@echo "📋 Using namespace: $(NAMESPACE)"
+	@if [ -n "$(MODEL_NAMESPACE)" ]; then echo "📋 Using model namespace: $(MODEL_NAMESPACE)"; fi
 	@bash -c '\
 		uv sync && \
 		chmod +x ./scripts/local-dev.sh && \
-		source .venv/bin/activate && ./scripts/local-dev.sh && \
+		if [ -n "$(MODEL_NAMESPACE)" ]; then \
+			./scripts/local-dev.sh -n $(NAMESPACE) -m $(MODEL_NAMESPACE); \
+		else \
+			./scripts/local-dev.sh -n $(NAMESPACE); \
+		fi && \
 		echo "✅ Local development environment setup completed" \
 	'
 

--- a/Makefile
+++ b/Makefile
@@ -40,7 +40,16 @@ endif
 POSTGRES_USER ?= postgres
 POSTGRES_PASSWORD ?= rag_password
 POSTGRES_DBNAME ?= rag_blueprint
-HF_TOKEN ?= $(shell bash -c 'read -r -p "Enter Hugging Face Token: " HF_TOKEN; echo $$HF_TOKEN')
+
+# HF_TOKEN is only required if LLM_URL is not set
+HF_TOKEN ?= $(shell \
+    if [ -n "$(LLM_URL)" ]; then \
+        echo ""; \
+    else \
+        bash -c 'read -r -p "Enter Hugging Face Token: " HF_TOKEN; echo $$HF_TOKEN'; \
+    fi \
+)
+
 RAG_CHART := rag
 METRIC_API_RELEASE_NAME ?= metrics-api
 METRIC_API_CHART_PATH ?= metrics-api
@@ -70,10 +79,13 @@ ALERTING_RELEASE_NAME ?= alerting
 OBSERVABILITY_NAMESPACE ?= observability-hub # currently hard-coded in instrumentation.yaml
 INSTRUMENTATION_PATH ?= observability/otel-collector/scripts/instrumentation.yaml
 
+# LLM URL processing constants
+DEFAULT_LLM_PORT_AND_PATH := :8080/v1
+
 # Helm argument templates
 
 helm_llm_service_args = \
-    --set llm-service.secret.hf_token=$(HF_TOKEN) \
+    $(if $(LLM_URL),,--set llm-service.secret.hf_token=$(HF_TOKEN)) \
     $(if $(DEVICE),--set llm-service.device='$(DEVICE)',) \
     $(if $(LLM),--set global.models.$(LLM).enabled=true,) \
     $(if $(SAFETY),--set global.models.$(SAFETY).enabled=true,) \
@@ -81,10 +93,21 @@ helm_llm_service_args = \
     $(if $(SAFETY_TOLERATION),--set-json global.models.$(SAFETY).tolerations='$(call TOLERATIONS_TEMPLATE,$(SAFETY_TOLERATION))',) \
     $(if $(RAW_DEPLOYMENT),--set llm-service.rawDeploymentMode=$(RAW_DEPLOYMENT),)
 
+# Process LLM_URL to add default port and /v1 if port is missing
+define process_llm_url
+$(if $(LLM_URL),$(shell \
+    if echo "$(LLM_URL)" | grep -q ":[0-9]"; then \
+        echo "$(LLM_URL)"; \
+    else \
+        echo "$(LLM_URL)$(DEFAULT_LLM_PORT_AND_PATH)"; \
+    fi \
+),)
+endef
+
 helm_llama_stack_args = \
     $(if $(LLM),--set global.models.$(LLM).enabled=true,) \
     $(if $(SAFETY),--set global.models.$(SAFETY).enabled=true,) \
-    $(if $(LLM_URL),--set global.models.$(LLM).url='$(LLM_URL)',) \
+    $(if $(LLM_URL),--set global.models.$(LLM).url='$(call process_llm_url)',) \
     $(if $(SAFETY_URL),--set global.models.$(SAFETY).url='$(SAFETY_URL)',) \
     $(if $(LLM_API_TOKEN),--set global.models.$(LLM).apiToken='$(LLM_API_TOKEN)',) \
     $(if $(SAFETY_API_TOKEN),--set global.models.$(SAFETY).apiToken='$(SAFETY_API_TOKEN)',) \
@@ -156,9 +179,10 @@ help:
 	@echo "  PLATFORM           - Target platform (default: linux/amd64)"
 	@echo "  BUILD_TOOL         - Build tool: docker or podman (auto-detected)"
 	@echo "  NAMESPACE          - OpenShift namespace for deployment"
-	@echo "  HF_TOKEN           - Hugging Face Token (will prompt if not provided)"
+	@echo "  HF_TOKEN           - Hugging Face Token (will prompt if not provided and LLM_URL not set)"
 	@echo "  DEVICE             - Deploy models on cpu or gpu (default)"
 	@echo "  LLM                - Model id (eg. llama-3-2-3b-instruct)"
+	@echo "  LLM_URL            - Use existing model URL (auto-adds :8080/v1 if no port specified)"
 	@echo "  SAFETY             - Safety model id"
 	@echo "  ALERTS             - Set to TRUE to install alerting with main deployment"
 	@echo "  SLACK_WEBHOOK_URL  - Slack Webhook URL for alerting (will prompt if not provided)"

--- a/Makefile
+++ b/Makefile
@@ -297,8 +297,6 @@ install-metric-ui: namespace
 install-mcp-server: namespace
 	@echo "Deploying MCP Server"
 	@cd deploy/helm && helm upgrade --install $(MCP_SERVER_RELEASE_NAME) $(MCP_SERVER_CHART_PATH) -n $(NAMESPACE) \
-		--set image.repository=$(MCP_SERVER_IMAGE) \
-		--set image.tag=$(VERSION) \
 		$(if $(MCP_SERVER_ROUTE_HOST),--set route.host='$(MCP_SERVER_ROUTE_HOST)',)
 
 .PHONY: install-rag

--- a/README.md
+++ b/README.md
@@ -167,16 +167,25 @@ This will install the project with the default LLM deployment, `llama-3-2-3b-ins
 
 ### Using an Existing Model
 
-To use an existing model instead of deploying a new one, specify `LLM_URL` to be `<model service url>:PORT/v1`:
+To use an existing model instead of deploying a new one, specify `LLM_URL` as the model service URL:
 
 ```bash
+# URL with port (no processing applied)
 make install LLM_URL=http://llama-3-2-3b-instruct-predictor.dev.svc.cluster.local:8080/v1 NAMESPACE=your-namespace
+
+# URL without port (automatically adds :8080/v1)
+make install LLM_URL=http://llama-3-2-3b-instruct-predictor.dev.svc.cluster.local NAMESPACE=your-namespace
 ```
+
+**URL Processing**: If the `LLM_URL` doesn't contain a port (`:PORT` format), the system will automatically append `:8080/v1` to the URL. This simplifies configuration while maintaining flexibility for custom ports.
+
+**Token Management**: When `LLM_URL` is specified, the system will not prompt for a Hugging Face token since you're using an existing model that doesn't require new model deployment.
 
 This is useful when:
 - You already have a model deployed in your cluster
 - You want to share a model across multiple namespaces
 - You prefer not to deploy redundant model instances
+- You want to avoid unnecessary token prompts for external models
 
 ### Choosing different models
 

--- a/README.md
+++ b/README.md
@@ -165,6 +165,19 @@ make install NAMESPACE=your-namespace
 ```
 This will install the project with the default LLM deployment, `llama-3-2-3b-instruct`.
 
+### Using an Existing Model
+
+To use an existing model instead of deploying a new one, specify `LLM_URL` to be `<model service url>:PORT/v1`:
+
+```bash
+make install LLM_URL=http://llama-3-2-3b-instruct-predictor.dev.svc.cluster.local:8080/v1 NAMESPACE=your-namespace
+```
+
+This is useful when:
+- You already have a model deployed in your cluster
+- You want to share a model across multiple namespaces
+- You prefer not to deploy redundant model instances
+
 ### Choosing different models
 
 To see all available models:

--- a/README.md
+++ b/README.md
@@ -407,7 +407,10 @@ For local development with port-forwarding:
 
 ```bash
 # Set up local development environment
-make deploy-local
+make install-local NAMESPACE=your-namespace
+
+# If model is in different namespace
+make install-local NAMESPACE=default-ns MODEL_NAMESPACE=model-ns
 ```
 
 This will run the `./scripts/local-dev.sh` script to set up port-forwarding to Llamastack, llm-service, and Thanos.
@@ -441,7 +444,7 @@ The easiest way to set up local development is using the Makefile:
 
 ```bash
 # Set up local development environment
-make deploy-local
+make install-local NAMESPACE=your-namespace
 ```
 
 This will run the `./scripts/local-dev.sh` script automatically.
@@ -457,18 +460,20 @@ If you prefer to run the script manually, follow these steps:
 ```bash
 # 1. Setup environment
 uv sync --group dev
-source .venv/bin/activate
+# Note: Virtual environment activation is handled automatically by the script
 
-# 2. Export your namespace  
-export LLM_NAMESPACE=<DESIRED_NAMESPACE>
+# 2. Start development environment (includes all port forwarding)
+./scripts/local-dev.sh -n <DEFAULT_NAMESPACE>
 
-# 3. Start development environment (includes all port forwarding)
-./scripts/local-dev.sh
+# 3. If model is in different namespace (optional)
+./scripts/local-dev.sh -n <DEFAULT_NAMESPACE> -m <MODEL_NAMESPACE>
 ```
 
 ### What the script does:
+- ✅ **Activates Python virtual environment** (.venv)
 - ✅ **Port forwards Prometheus/Thanos** (localhost:9090)
 - ✅ **Port forwards LLM server** (localhost:8321) 
+- ✅ **Port forwards Model service** (localhost:8080)
 - ✅ **Starts metrics API** (localhost:8000)
 - ✅ **Starts Streamlit UI** (localhost:8501)
 - ✅ **Configures environment** for MCP server development

--- a/docs/DEV_GUIDE.md
+++ b/docs/DEV_GUIDE.md
@@ -181,10 +181,16 @@ make install NAMESPACE=your-namespace LLM_TOLERATION="nvidia.com/gpu"
 # Deploy with safety models (deploys default model)
 make install NAMESPACE=your-namespace SAFETY=llama-guard-3-8b
 
-# Use existing model (specify LLM_URL as <model service url>:PORT/v1)
-# In the example given below, the model service (llama-3-2-3b-instruct-predictor) is running in "dev" cluster
+# Use existing model (specify LLM_URL as model service URL)
+# Note: When LLM_URL is provided, HF_TOKEN will not be prompted since no new model deployment is needed
+
+# URL with port (no processing applied):
 make install NAMESPACE=your-namespace \
   LLM_URL=http://llama-3-2-3b-instruct-predictor.dev.svc.cluster.local:8080/v1
+
+# URL without port (automatically adds :8080/v1):
+make install NAMESPACE=your-namespace \
+  LLM_URL=http://llama-3-2-3b-instruct-predictor.dev.svc.cluster.local
 
 # Deploy individual components
 make install-metric-mcp NAMESPACE=your-namespace    # Metrics API only
@@ -209,6 +215,8 @@ make list-models
 - `PROMETHEUS_URL`: Thanos/Prometheus endpoint (default: http://localhost:9090)
 - `LLAMA_STACK_URL`: LLM backend URL (default: http://localhost:8321/v1/openai/v1)
 - `LLM_API_TOKEN`: API token for LLM service
+- `LLM_URL`: Use existing model URL (skips HF_TOKEN prompt and model deployment)
+- `HF_TOKEN`: Hugging Face token (auto-prompted only when LLM_URL is not set)
 - `MODEL_CONFIG`: JSON configuration for available models
 - `THANOS_TOKEN`: Authentication token (default: reads from service account)
 - `SLACK_WEBHOOK_URL`: Slack webhook for alerting notifications

--- a/docs/DEV_GUIDE.md
+++ b/docs/DEV_GUIDE.md
@@ -33,10 +33,23 @@ summarizer/
 │   │   └── thanos_service.py # Thanos integration
 │   ├── ui/                # Streamlit UI
 │   │   └── ui.py         # Multi-dashboard interface
+│   ├── mcp_server/        # Model Context Protocol server
+│   │   ├── api.py         # MCP API implementation
+│   │   ├── main.py        # HTTP server entrypoint
+│   │   ├── stdio_server.py # STDIO server for AI assistants
+│   │   ├── tools/         # MCP tools (observability_tools.py)
+│   │   └── integrations/  # AI assistant integration configs
 │   └── alerting/          # Alerting service
 │       └── alert_receiver.py # Alert handling
 ├── deploy/helm/           # Helm charts for deployment
+│   ├── mcp-server/        # MCP server Helm chart
+│   ├── metrics-api/       # Metrics API Helm chart
+│   ├── ui/                # UI Helm chart
+│   └── rag/               # RAG components (llama-stack, llm-service)
 ├── tests/                 # Test suite
+│   ├── mcp/               # MCP server tests
+│   ├── core/              # Core logic tests
+│   └── alerting/          # Alerting tests
 ├── scripts/               # Development and deployment scripts
 └── docs/                  # Documentation
 ```
@@ -84,8 +97,9 @@ summarizer/
 1. **Metrics API** (`src/api/metrics_api.py`): FastAPI backend serving metrics analysis and chat endpoints
 2. **UI** (`src/ui/ui.py`): Streamlit multi-dashboard frontend
 3. **Core Logic** (`src/core/`): Business logic modules for metrics processing and LLM integration
-4. **Alerting** (`src/alerting/`): Alert handling and Slack notifications
-5. **Helm Charts** (`deploy/helm/`): OpenShift deployment configuration
+4. **MCP Server** (`src/mcp_server/`): Model Context Protocol server for AI assistant integration
+5. **Alerting** (`src/alerting/`): Alert handling and Slack notifications
+6. **Helm Charts** (`deploy/helm/`): OpenShift deployment configuration
 
 ### Data Flow
 1. **Natural Language Question** → PromQL generation via LLM
@@ -144,6 +158,7 @@ make build
 make build-metrics-api    # FastAPI backend
 make build-ui            # Streamlit UI
 make build-alerting      # Alerting service
+make build-mcp-server    # MCP server
 
 # Build with custom tag
 make build TAG=v1.0.0
@@ -170,6 +185,10 @@ make install NAMESPACE=your-namespace SAFETY=llama-guard-3-8b
 # In the example given below, the model service (llama-3-2-3b-instruct-predictor) is running in "dev" cluster
 make install NAMESPACE=your-namespace \
   LLM_URL=http://llama-3-2-3b-instruct-predictor.dev.svc.cluster.local:8080/v1
+
+# Deploy individual components
+make install-metric-mcp NAMESPACE=your-namespace    # Metrics API only
+make install-mcp-server NAMESPACE=your-namespace    # MCP server only
 ```
 
 ### Management
@@ -332,10 +351,13 @@ oc port-forward svc/metrics-api 8000:8000 -n <DEFAULT_NAMESPACE>
 - `make build-metrics-api` - Build FastAPI backend
 - `make build-ui` - Build Streamlit UI
 - `make build-alerting` - Build alerting service
+- `make build-mcp-server` - Build MCP server
 
 ### Deployment
 - `make install` - Deploy to OpenShift
 - `make install-with-alerts` - Deploy with alerting
+- `make install-metric-mcp` - Deploy metrics API only
+- `make install-mcp-server` - Deploy MCP server only
 - `make status` - Check deployment status
 - `make uninstall` - Remove deployment
 
@@ -440,6 +462,7 @@ oc get events -n <DEFAULT_NAMESPACE> --sort-by='.lastTimestamp'
 - **Main API**: `src/api/metrics_api.py`
 - **Core Logic**: `src/core/llm_summary_service.py`
 - **UI**: `src/ui/ui.py`
+- **MCP Server**: `src/mcp_server/main.py`
 - **Tests**: `tests/`
 - **Helm Charts**: `deploy/helm/`
 

--- a/docs/DEV_GUIDE.md
+++ b/docs/DEV_GUIDE.md
@@ -151,24 +151,25 @@ make build TAG=v1.0.0
 
 ### Deployment
 ```bash
-# Deploy to OpenShift
+# Deploy to OpenShift (deploys default model)
 make install NAMESPACE=your-namespace
 
-# Deploy with alerting
+# Deploy with alerting (deploys default model)
 make install-with-alerts NAMESPACE=your-namespace
 
 # Deploy with specific LLM model
-make install NAMESPACE=your-namespace LLM=llama-3-2-3b-instruct
+make install NAMESPACE=your-namespace LLM=llama-3-2-1b-instruct
 
-# Deploy with GPU tolerations
-make install NAMESPACE=your-namespace \
-  LLM=llama-3-2-3b-instruct \
-  LLM_TOLERATION="nvidia.com/gpu"
+# Deploy with GPU tolerations (deploys default model)
+make install NAMESPACE=your-namespace LLM_TOLERATION="nvidia.com/gpu"
 
-# Deploy with safety models
+# Deploy with safety models (deploys default model)
+make install NAMESPACE=your-namespace SAFETY=llama-guard-3-8b
+
+# Use existing model (specify LLM_URL as <model service url>:PORT/v1)
+# In the example given below, the model service (llama-3-2-3b-instruct-predictor) is running in "dev" cluster
 make install NAMESPACE=your-namespace \
-  LLM=llama-3-2-3b-instruct \
-  SAFETY=llama-guard-3-8b
+  LLM_URL=http://llama-3-2-3b-instruct-predictor.dev.svc.cluster.local:8080/v1
 ```
 
 ### Management

--- a/scripts/local-dev.sh
+++ b/scripts/local-dev.sh
@@ -11,7 +11,6 @@ NC='\033[0m' # No Color
 
 # Configuration
 PROMETHEUS_NAMESPACE="openshift-monitoring"
-LLM_NAMESPACE="${LLM_NAMESPACE:-test1}"
 METRIC_API_APP="metrics-api-app"
 THANOS_PORT=9090
 LLAMASTACK_PORT=8321
@@ -23,31 +22,106 @@ UI_PORT=8501
 echo -e "${BLUE}🚀 AI Observability Metric Summarizer - Local Development Setup${NC}"
 echo "=============================================================="
 
+# Function to display usage
+usage() {
+    echo "Usage: $0 [OPTIONS]"
+    echo ""
+    echo "Options:"
+    echo "  -n/-N NAMESPACE              Default namespace for pods (required)"
+    echo "  -m/-M NAMESPACE              Llama Model namespace (optional, use if model is in different namespace)"
+    echo ""
+    echo "Examples:"
+    echo "  $0 -n default-ns                       # All pods/services in same namespace"
+    echo "  $0 -N default-ns                       # All pods/services in same namespace (uppercase)"
+    echo "  $0 -n default-ns -m model-ns           # Model in different namespace than other pods/services"
+}
+
+# Function to parse command line arguments
+parse_args() {
+    # Check if no arguments provided
+    if [ $# -eq 0 ]; then
+        usage
+        exit 2
+    fi
+
+    DEFAULT_NAMESPACE=""
+    LLAMA_MODEL_NAMESPACE=""
+
+    while getopts "n:N:m:M:" opt; do
+        case $opt in
+            n|N) DEFAULT_NAMESPACE="$OPTARG"
+                 ;;
+            m|M) LLAMA_MODEL_NAMESPACE="$OPTARG"
+                 ;;
+            *) echo -e "${RED}❌ INVALID option: [$OPTARG]${NC}"
+               usage
+               exit 1
+               ;;
+        esac
+    done
+
+    # Validate arguments
+    if [ -z "$DEFAULT_NAMESPACE" ]; then
+        echo -e "${RED}❌ Default namespace is required. Please specify using -n or -N${NC}"
+        usage
+        exit 1
+    fi
+
+    # Set llama model namespace to default if not provided
+    if [ -z "$LLAMA_MODEL_NAMESPACE" ]; then
+        LLAMA_MODEL_NAMESPACE="$DEFAULT_NAMESPACE"
+    fi
+}
+
 # Function to cleanup on exit
 cleanup() {
+    # Prevent multiple cleanup calls
+    if [ "$CLEANUP_DONE" = "true" ]; then
+        return
+    fi
+    CLEANUP_DONE=true
+
     echo -e "\n${YELLOW}🧹 Cleaning up services and port-forwards...${NC}"
+    ensure_port_free "$METRICS_API_PORT"
     pkill -f "oc port-forward" || true
     pkill -f "uvicorn.*metrics_api:app" || true
     pkill -f "streamlit run ui.py" || true
+
+    # Deactivate virtual environment if it was activated
+    if [ -n "$VIRTUAL_ENV" ]; then
+        echo -e "${BLUE}🐍 Deactivating virtual environment...${NC}"
+        deactivate
+    fi
+
     echo -e "${GREEN}✅ Cleanup complete${NC}"
 }
-trap cleanup EXIT INT TERM
 
-# Function to check if service exists
+# Function to check prerequisites and activate virtual environment
 check_prerequisites() {
     echo -e "${BLUE}🔍 Checking prerequisites...${NC}"
-    
+
+    # Check for virtual environment and activate it
+    if [ -f ".venv/bin/activate" ]; then
+        echo -e "${BLUE}🐍 Activating Python virtual environment...${NC}"
+        source .venv/bin/activate
+        echo -e "${GREEN}✅ Virtual environment activated${NC}"
+    else
+        echo -e "${YELLOW}⚠️  Virtual environment (.venv) not found${NC}"
+        echo -e "${YELLOW}   Please create virtual environment by following README or DEV_GUIDE${NC}"
+        exit 1
+    fi
+
     if ! command -v oc &> /dev/null; then
         echo -e "${RED}❌ OpenShift CLI (oc) is not installed${NC}"
         exit 1
     fi
-    
+
     if ! oc whoami &> /dev/null; then
         echo -e "${RED}❌ Not logged in to OpenShift cluster${NC}"
         echo -e "${YELLOW}   Please run: oc login${NC}"
         exit 1
     fi
-    
+
     echo -e "${GREEN}✅ Prerequisites check passed${NC}"
 }
 
@@ -71,23 +145,23 @@ start_port_forwards() {
     fi
     
     # Find LlamaStack pod
-    LLAMASTACK_POD=$(oc get pods -n "$LLM_NAMESPACE" -o name | grep -E "(llama-stack|llamastack)" | head -1 | cut -d'/' -f2 || echo "")
+    LLAMASTACK_POD=$(oc get pods -n "$DEFAULT_NAMESPACE" -o name | grep -E "(llama-stack|llamastack)" | head -1 | cut -d'/' -f2 || echo "")
     if [ -n "$LLAMASTACK_POD" ]; then
         echo -e "${GREEN}✅ Found LlamaStack pod: $LLAMASTACK_POD${NC}"
-        oc port-forward pod/"$LLAMASTACK_POD" "$LLAMASTACK_PORT:8321" -n "$LLM_NAMESPACE" &
+        oc port-forward pod/"$LLAMASTACK_POD" "$LLAMASTACK_PORT:8321" -n "$DEFAULT_NAMESPACE" &
         echo -e "${GREEN}   🦙 LlamaStack available at: http://localhost:$LLAMASTACK_PORT${NC}"
     else
         echo -e "${YELLOW}⚠️  LlamaStack pod not found${NC}"
     fi
     
-    # Find Llama Model pod
-    LLAMA_MODEL_POD=$(oc get pods -n "$LLM_NAMESPACE" -o name | grep -E "(llama-3|inference)" | grep -v stack | head -1 | cut -d'/' -f2 || echo "")
-    if [ -n "$LLAMA_MODEL_POD" ]; then
-        echo -e "${GREEN}✅ Found Llama Model pod: $LLAMA_MODEL_POD${NC}"
-        oc port-forward pod/"$LLAMA_MODEL_POD" "$LLAMA_MODEL_PORT:8080" -n "$LLM_NAMESPACE" &
+    # Find Llama Model service
+    LLAMA_MODEL_SERVICE=$(oc get services -n "$LLAMA_MODEL_NAMESPACE" -o name | grep -E "(llama-3|predictor)" | grep -v stack | head -1 | cut -d'/' -f2 || echo "")
+    if [ -n "$LLAMA_MODEL_SERVICE" ]; then
+        echo -e "${GREEN}✅ Found Llama Model service: $LLAMA_MODEL_SERVICE in [$LLAMA_MODEL_NAMESPACE] namespace${NC}"
+        oc port-forward service/"$LLAMA_MODEL_SERVICE" "$LLAMA_MODEL_PORT:8080" -n "$LLAMA_MODEL_NAMESPACE" &
         echo -e "${GREEN}   🤖 Llama Model available at: http://localhost:$LLAMA_MODEL_PORT${NC}"
     else
-        echo -e "${YELLOW}⚠️  Llama Model pod not found${NC}"
+        echo -e "${YELLOW}⚠️  Llama Model service not found in namespace: $LLAMA_MODEL_NAMESPACE${NC}"
     fi
     
     sleep 3  # Give port-forwards time to establish
@@ -114,14 +188,13 @@ ensure_port_free() {
 }
 
 # This function sets "MODEL_CONFIG" envrionment variable by reading it from "$METRIC_API_APP" deployment
-function set_model_config() {
+set_model_config() {
     # Find metrics-api-app deployment
-    # MODEL_CONFIG=$(oc get deploy 'metrics-api-app' -n"$LLM_NAMESPACE" -o json -o jsonpath='{.spec.template.spec.containers..env}' | jq '.[] | select(.name == "MODEL_CONFIG") | .value')
 
-    METRIC_API_DEPLOYMENT=$(oc get deploy "$METRIC_API_APP" -n "$LLM_NAMESPACE")
+    METRIC_API_DEPLOYMENT=$(oc get deploy "$METRIC_API_APP" -n "$DEFAULT_NAMESPACE")
     if [ -n "$METRIC_API_DEPLOYMENT" ]; then
         echo -e "${GREEN}✅ Found [$METRIC_API_APP] deployment: $METRIC_API_DEPLOYMENT${NC}"
-        export $(oc set env deployment/$METRIC_API_APP --list  -n "$LLM_NAMESPACE" | grep MODEL_CONFIG)
+        export $(oc set env deployment/$METRIC_API_APP --list  -n "$DEFAULT_NAMESPACE" | grep MODEL_CONFIG)
         if [ -n "$MODEL_CONFIG" ]; then
           echo -e "${GREEN}✅   MODEL_CONFIG set to: $MODEL_CONFIG${NC}"
         else
@@ -183,10 +256,17 @@ start_local_services() {
 
 # Main execution
 main() {
+    parse_args "$@"
     check_prerequisites
+
+    # Set cleanup trap only after successful prerequisite checks
+    trap cleanup EXIT INT TERM
+
     echo ""
     echo -e "${BLUE}--------------------------------${NC}"
-    echo -e "${BLUE}Namespace being used for setup -> LLM_NAMESPACE: $LLM_NAMESPACE${NC}"
+    echo -e "${BLUE}Namespaces being used for setup:${NC}"
+    echo -e "${BLUE}  DEFAULT_NAMESPACE: $DEFAULT_NAMESPACE${NC}"
+    echo -e "${BLUE}  LLAMA_MODEL_NAMESPACE: $LLAMA_MODEL_NAMESPACE${NC}"
     echo -e "${BLUE}--------------------------------${NC}\n"
 
     start_port_forwards
@@ -209,4 +289,4 @@ main() {
 }
 
 # Run main function
-main 
+main "$@"

--- a/scripts/local-dev.sh
+++ b/scripts/local-dev.sh
@@ -151,7 +151,8 @@ start_port_forwards() {
         oc port-forward pod/"$LLAMASTACK_POD" "$LLAMASTACK_PORT:8321" -n "$DEFAULT_NAMESPACE" &
         echo -e "${GREEN}   🦙 LlamaStack available at: http://localhost:$LLAMASTACK_PORT${NC}"
     else
-        echo -e "${YELLOW}⚠️  LlamaStack pod not found${NC}"
+        echo -e "${RED}❌  LlamaStack pod not found. Exiting...${NC}"
+        exit 1
     fi
     
     # Find Llama Model service
@@ -161,7 +162,8 @@ start_port_forwards() {
         oc port-forward service/"$LLAMA_MODEL_SERVICE" "$LLAMA_MODEL_PORT:8080" -n "$LLAMA_MODEL_NAMESPACE" &
         echo -e "${GREEN}   🤖 Llama Model available at: http://localhost:$LLAMA_MODEL_PORT${NC}"
     else
-        echo -e "${YELLOW}⚠️  Llama Model service not found in namespace: $LLAMA_MODEL_NAMESPACE${NC}"
+        echo -e "${RED}❌  Llama Model service not found in namespace: $LLAMA_MODEL_NAMESPACE. Exiting...${NC}"
+        exit 1
     fi
     
     sleep 3  # Give port-forwards time to establish


### PR DESCRIPTION
## Changes

1. Using `LLM_URL` parameter from command line, for Existing Models, when running `make install`
2. Enhanced `local-dev.sh` with improved namespace flexibility, automatic virtual environment management, service-based port forwarding, and updated all related documentation and build targets.
3. Removed use of `LLM_NAMESPACE` for `local-dev.sh`

 ### New Usage Examples

  #### Install using an existing model

  * Use existing model instead of deploying a new one

    `make install NAMESPACE=your-namespace LLM_URL=<model service url>:PORT/v1`

     OR 

    `make install NAMESPACE=your-namespace LLM_URL=<model service url>`      # `:8080/v1` _will be appended to the LLM_URL automatically_

  * _HF_TOKEN is not required when LLM_URL is provided on cli_

  * Command used to install in `sgahlot-test` namespace while pointing to an existing model in `dev` namespace:
    ```
    # Model "llama-3-2-3b-instruct" is running in "dev" namespace
    make install NAMESPACE=sgahlot-test \
       LLM_URL=http://llama-3-2-3b-instruct-predictor.dev.svc.cluster.local:8080/v1
    ```

  * Command used to install in `sgahlot-test` namespace while pointing to an existing model in `dev` namespace (_without providing port_):
    ```
    # Model "llama-3-2-3b-instruct" is running in "dev" namespace - no port provided in LLM_URL
    make install NAMESPACE=sgahlot-test \
       LLM_URL=http://llama-3-2-3b-instruct-predictor.dev.svc.cluster.local
    ```

  #### Run locally - _Makefile usage_

  `make install-local NAMESPACE=default-ns`                 # All services in same namespace
  `make install-local NAMESPACE=default-ns MODEL_NAMESPACE=model-ns`  # Model in different namespace

  * Command used to test with an existing model:
    ```
    # Uses llm-model service from "dev" namespace
    make install-local NAMESPACE=sgahlot-test MODEL_NAMESPACE=dev
    ```

  #### Run locally - _Script usage_
  `./scripts/local-dev.sh -n default-ns`                    # All services in same namespace
  `./scripts/local-dev.sh -n default-ns -m model-ns`       # Model in different namespace

  * Command used to test:
    ```
    # Uses llm-model service from "dev" namespace
    ./scripts/local-dev.sh -n sgahlot-test -m dev
    ```


  🔧 Core Script Changes (scripts/local-dev.sh)

  New Features

  - Flexible namespace support: Added optional -m/-M parameter for separate model namespace
  - Automatic virtual environment management: Script activates .venv on startup and deactivates on exit
  - Service-based port forwarding: Switched from pod-based to service-based forwarding for model service (more reliable)
  - Improved error handling: Better error messages, validation, and graceful cleanup

  Parameter Changes

  - Renamed variables: LLM_NAMESPACE → DEFAULT_NAMESPACE for better semantic clarity
  - New parameter structure:
    - -n/-N: Default namespace for most services (required)
    - -m/-M: Model namespace (optional, defaults to default namespace)

  Enhanced Features

  - Prerequisites validation: Checks for virtual environment, OpenShift login, and required tools
  - Better service discovery: More robust pod/service finding with clear status messages
  - Namespace display: Shows both namespaces being used during setup

  📚 Documentation Updates

  README.md
  DEV_GUIDE.md


  🏗️ Build System Updates (Makefile)

  Enhanced install-local target

  - Parameter validation: Requires NAMESPACE, supports optional MODEL_NAMESPACE


  🧪 Testing & Validation

  - ✅ Virtual environment activation/deactivation lifecycle
  - ✅ Port forwarding with separate namespaces
  - ✅ Service discovery and error handling
  - ✅ Parameter validation and error messages
  - ✅ Documentation accuracy across all files
  - ✅ Makefile target functionality


## Screennshots

* Shows LLM service running in `dev` namespace:
<img width="1459" height="963" alt="01-llama_service_in_dev" src="https://github.com/user-attachments/assets/befa71ae-5586-4cdb-9fc4-d15b3cb3d70f" />

* Shows `sgahlot-test` namespace that does NOT have any LLM model
<img width="1543" height="795" alt="02-no_llama_model_deployment" src="https://github.com/user-attachments/assets/23aa8051-bfa7-4dd6-95db-105d0934b672" />

* Shows `sgahlot-test` namespace that does NOT have any LLM model service
<img width="1520" height="937" alt="03-no_llama_model_svc" src="https://github.com/user-attachments/assets/677b7357-284a-4385-97cf-0a4944083971" />

* Screenshot from local run - showing vLLM metrics
<img width="1504" height="1340" alt="04-local_run-vllm_metrics" src="https://github.com/user-attachments/assets/1d25f26c-fb12-4c54-b4d8-2908a1505c9c" />

* Screenshot from local run - showing OCP metrics (fleet wide)
<img width="1514" height="1579" alt="05-local_run-ocp_metrics_fleet" src="https://github.com/user-attachments/assets/9657e7f7-2cd6-4a8d-bb78-159be00910c2" />

* Screenshot from local run - showing OCP metrics (namespace level)
<img width="1514" height="1579" alt="06-local_run-ocp_metrics_ns" src="https://github.com/user-attachments/assets/7fb8debd-c3b9-41d4-a0dd-bb04ed35aab2" />

* Screenshot from local run - showing Chat with Prometheus
<img width="1514" height="1194" alt="07-chat" src="https://github.com/user-attachments/assets/766b264d-98a7-45a5-868e-a92a03a1d0ad" />



## Checklist

- [x] Verify on the cluster
- [ ] Update tests if applicable and run `pytest`
- [x] Add screenshots (if applicable)
- [x] Update readme (if applicable)