### PR TITLE
feat(ui): migrate vLLM metrics analysis to mcp-server

### DIFF
--- a/deploy/helm/mcp-server/templates/deployment.yaml
+++ b/deploy/helm/mcp-server/templates/deployment.yaml
@@ -50,13 +50,16 @@ spec:
                 secretKeyRef:
                   name: mcp-analyzer
                   key: token
+            - name: LLM_URL
+              value: "http://llama-3-2-3b-instruct-predictor.{{ .Release.Namespace }}.svc.cluster.local:8080/v1/openai/v1"
+            - name: LLM_API_TOKEN
+              value: "{{ .Values.llm.apiToken }}"
             {{- if .Values.llm.url }}
             - name: LLAMA_STACK_URL
               value: "{{ .Values.llm.url }}"
-            {{- end }}
-            {{- if .Values.llm.apiToken }}
-            - name: LLM_API_TOKEN
-              value: "{{ .Values.llm.apiToken }}"
+            {{- else }}
+            - name: LLAMA_STACK_URL
+              value: "http://llamastack.{{ .Release.Namespace }}.svc.cluster.local:8321/v1/openai/v1"
             {{- end }}
             - name: MODEL_CONFIG
               value: '{{ .Values.modelConfig | toJson }}'

--- a/src/mcp_server/mcp.py
+++ b/src/mcp_server/mcp.py
@@ -21,7 +21,9 @@ class ObservabilityMCPServer:
             list_models,
             list_namespaces,
             get_model_config,
+            get_vllm_metrics_tool,
             analyze_vllm,
+            calculate_metrics,
         )
         from .tools.observability_openshift_tools import (
             analyze_openshift,
@@ -32,7 +34,9 @@ class ObservabilityMCPServer:
         self.mcp.tool()(list_models)
         self.mcp.tool()(list_namespaces)
         self.mcp.tool()(get_model_config)
+        self.mcp.tool()(get_vllm_metrics_tool)
         self.mcp.tool()(analyze_vllm)
+        self.mcp.tool()(calculate_metrics)
         self.mcp.tool()(analyze_openshift)
         self.mcp.tool()(list_openshift_metric_groups)
         self.mcp.tool()(list_openshift_namespace_metric_groups)

--- a/src/ui/ui.py
+++ b/src/ui/ui.py
@@ -9,7 +9,7 @@ import base64
 import matplotlib.pyplot as plt
 import io
 import time
-from mcp_client_helper import get_namespaces_mcp, get_models_mcp, get_model_config_mcp
+from mcp_client_helper import get_namespaces_mcp, get_models_mcp, get_model_config_mcp, analyze_vllm_mcp, calculate_metrics_mcp, get_vllm_metrics_mcp
 
 # --- Config ---
 API_URL = os.getenv("METRICS_API_URL", "http://localhost:8000")
@@ -131,12 +131,16 @@ def get_openshift_namespaces():
 
 @st.cache_data(ttl=300)
 def get_vllm_metrics():
-    """Fetch available vLLM metrics dynamically from API"""
+    """Fetch available vLLM metrics from MCP server only"""
     try:
-        res = requests.get(f"{API_URL}/vllm-metrics")
-        return res.json()
+        metrics = get_vllm_metrics_mcp()
+        if metrics:
+            return metrics
+        else:
+            st.sidebar.warning("⚠️ No vLLM metrics found in MCP server")
+            return {}
     except Exception as e:
-        st.sidebar.error(f"Error fetching vLLM metrics: {e}")
+        st.sidebar.error(f"❌ MCP Error: {str(e)}")
         return {}
 
 
@@ -316,13 +320,9 @@ def get_metrics_data_and_list():
 
 
 def get_calculated_metrics_from_mcp(metric_data):
-    """Get calculated metrics from MCP backend"""
+    """Get calculated metrics from MCP calculate_metrics tool"""
     try:
-        response = requests.post(
-            f"{API_URL}/calculate-metrics", json={"metrics_data": metric_data}
-        )
-        response.raise_for_status()
-        return response.json()["calculated_metrics"]
+        return calculate_metrics_mcp(metric_data)
     except Exception as e:
         st.error(f"Error getting calculated metrics from MCP: {e}")
         return {}
@@ -845,27 +845,34 @@ if page == "vLLM Metric Summarizer":
     if st.button("🔍 Analyze Metrics"):
         with st.spinner("Analyzing metrics..."):
             try:
-                # Get parameters from sidebar
-                params = {
+                # Analyze metrics via MCP server
+                result = analyze_vllm_mcp(
+                    model_name=model_name,
+                    summarize_model_id=multi_model_name,
+                    start_ts=selected_start,
+                    end_ts=selected_end,
+                    api_key=api_key,
+                )
+
+                if not result:
+                    st.error("❌ MCP analysis failed - no data returned")
+                    st.stop()
+
+                # Store results in session state
+                st.session_state["prompt"] = result["health_prompt"]
+                st.session_state["summary"] = result["llm_summary"]
+                st.session_state["model_name"] = model_name
+                st.session_state["metric_data"] = result.get("metrics", {})
+
+                # Store analysis parameters for report generation
+                analysis_params = {
                     "model_name": model_name,
                     "start_ts": selected_start,
                     "end_ts": selected_end,
                     "summarize_model_id": multi_model_name,
                     "api_key": api_key,
                 }
-
-                response = requests.post(f"{API_URL}/analyze", json=params)
-                response.raise_for_status()
-                result = response.json()
-
-                # Store results in session state
-                st.session_state["prompt"] = result["health_prompt"]
-                st.session_state["summary"] = result["llm_summary"]
-                st.session_state["model_name"] = params["model_name"]
-                st.session_state["metric_data"] = result.get("metrics", {})
-                st.session_state["analysis_params"] = (
-                    params  # Store for report generation
-                )
+                st.session_state["analysis_params"] = analysis_params
                 st.session_state["analysis_performed"] = (
                     True  # Mark that analysis was performed
                 )
@@ -873,9 +880,6 @@ if page == "vLLM Metric Summarizer":
                 # Force rerun to update the UI state (enable download button and hide warning)
                 st.rerun()
 
-            except requests.exceptions.HTTPError as http_err:
-                clear_session_state()
-                handle_http_error(http_err.response, "Analysis failed")
             except Exception as e:
                 clear_session_state()
                 st.error(f"❌ Error during analysis: {e}")

--- a/tests/mcp_server/test_mcp.py
+++ b/tests/mcp_server/test_mcp.py
@@ -28,7 +28,7 @@ def test_observability_mcp_server_registers_tools_and_reconfigures(
 
     # Assert
     assert server.mcp is mcp_instance
-    assert call_counter["count"] == 7  # seven tools registered
+    assert call_counter["count"] == 9  # 9 MCP tools registered (6 vLLM + 3 OpenShift)
     mock_get_logger.assert_called_once()
     mock_reconfigure.assert_called_once()
 

--- a/tests/mcp_server/test_vllm_tools.py
+++ b/tests/mcp_server/test_vllm_tools.py
@@ -1,13 +1,13 @@
 from unittest.mock import patch
 
-import mcp_server.tools.observability_vllm_tools as tools
+import src.mcp_server.tools.observability_vllm_tools as tools
 
 
 def _texts(result):
     return [part.get("text") for part in result]
 
 
-@patch("mcp_server.tools.observability_vllm_tools.get_models_helper", return_value=["a", "b"])  # type: ignore[arg-type]
+@patch("src.mcp_server.tools.observability_vllm_tools.get_models_helper", return_value=["a", "b"])  # type: ignore[arg-type]
 def test_list_models_success(_):
     out = tools.list_models()
     texts = _texts(out)
@@ -16,14 +16,14 @@ def test_list_models_success(_):
     assert any("b" in t for t in texts)
 
 
-@patch("mcp_server.tools.observability_vllm_tools.get_models_helper", return_value=[])  # type: ignore[arg-type]
+@patch("src.mcp_server.tools.observability_vllm_tools.get_models_helper", return_value=[])  # type: ignore[arg-type]
 def test_list_models_empty(_):
     out = tools.list_models()
     texts = _texts(out)
     assert any("No models are currently available" in t for t in texts)
 
 
-@patch("mcp_server.tools.observability_vllm_tools.get_namespaces_helper", return_value=["ns1", "ns2"])  # type: ignore[arg-type]
+@patch("src.mcp_server.tools.observability_vllm_tools.get_namespaces_helper", return_value=["ns1", "ns2"])  # type: ignore[arg-type]
 def test_list_namespaces_success(_):
     out = tools.list_namespaces()
     texts = _texts(out)
@@ -32,7 +32,7 @@ def test_list_namespaces_success(_):
     assert any("ns2" in t for t in texts)
 
 
-@patch("mcp_server.tools.observability_vllm_tools.get_namespaces_helper", return_value=[])  # type: ignore[arg-type]
+@patch("src.mcp_server.tools.observability_vllm_tools.get_namespaces_helper", return_value=[])  # type: ignore[arg-type]
 def test_list_namespaces_empty(_):
     out = tools.list_namespaces()
     texts = _texts(out)
@@ -55,17 +55,226 @@ def test_get_model_config_empty(_):
     assert any("No LLM models configured" in t for t in texts)
 
 
-@patch("mcp_server.tools.observability_vllm_tools.get_vllm_metrics", return_value={"latency": "q1", "tps": "q2"})
-@patch("mcp_server.tools.observability_vllm_tools.fetch_metrics", side_effect=[{"value": [1]}, {"value": [2]}])
-@patch("mcp_server.tools.observability_vllm_tools.build_prompt", return_value="PROMPT")
-@patch("mcp_server.tools.observability_vllm_tools.summarize_with_llm", return_value="SUMMARY")
-@patch("mcp_server.tools.observability_vllm_tools.extract_time_range_with_info", return_value=(1, 2, {}))
-def test_analyze_vllm_success(_, __, ___, ____, _____):
+@patch("src.mcp_server.tools.observability_vllm_tools.get_vllm_metrics", return_value={"latency": "q1", "tps": "q2"})
+@patch("src.mcp_server.tools.observability_vllm_tools.fetch_metrics")
+@patch("src.mcp_server.tools.observability_vllm_tools.build_prompt", return_value="PROMPT")
+@patch("src.mcp_server.tools.observability_vllm_tools.summarize_with_llm", return_value="SUMMARY")
+@patch("src.mcp_server.tools.observability_vllm_tools.extract_time_range_with_info", return_value=(1, 2, {}))
+def test_analyze_vllm_success(_, __, ___, mock_fetch, ____):
+    # Create proper DataFrame-like mock objects
+    import pandas as pd
+    from datetime import datetime
+    
+    # Mock DataFrame with required columns
+    mock_df1 = pd.DataFrame({
+        "timestamp": [datetime.now(), datetime.now()],
+        "value": [1.0, 2.0]
+    })
+    mock_df2 = pd.DataFrame({
+        "timestamp": [datetime.now(), datetime.now()],
+        "value": [3.0, 4.0]
+    })
+    
+    mock_fetch.side_effect = [mock_df1, mock_df2]
+    
     out = tools.analyze_vllm("model", "summarizer", time_range="last 1h")
     text = "\n".join(_texts(out))
     assert "Model: model" in text
     assert "PROMPT" in text
     assert "SUMMARY" in text
     assert "Metrics Preview" in text
+
+
+def test_calculate_metrics_success():
+    """Test calculate_metrics function with valid data"""
+    import json
+    
+    # Test data mimicking UI format
+    test_data = {
+        "GPU Temperature (°C)": [
+            {"timestamp": "2024-01-01T10:00:00", "value": 45.2},
+            {"timestamp": "2024-01-01T10:01:00", "value": 46.1},
+            {"timestamp": "2024-01-01T10:02:00", "value": 44.8}
+        ],
+        "GPU Power Usage (Watts)": [
+            {"timestamp": "2024-01-01T10:00:00", "value": 250.5},
+            {"timestamp": "2024-01-01T10:01:00", "value": 255.0}
+        ]
+    }
+    
+    metrics_json = json.dumps(test_data)
+    result = tools.calculate_metrics(metrics_json)
+    
+    # Extract text from MCP response
+    text = _texts(result)[0]
+    response_data = json.loads(text)
+    
+    assert "calculated_metrics" in response_data
+    calculated = response_data["calculated_metrics"]
+    
+    # Check GPU Temperature calculations
+    temp_stats = calculated["GPU Temperature (°C)"]
+    assert abs(temp_stats["avg"] - 45.366666666666667) < 0.001  # (45.2 + 46.1 + 44.8) / 3
+    assert temp_stats["min"] == 44.8
+    assert temp_stats["max"] == 46.1
+    assert temp_stats["latest"] == 44.8
+    assert temp_stats["count"] == 3
+    
+    # Check GPU Power calculations
+    power_stats = calculated["GPU Power Usage (Watts)"]
+    assert power_stats["avg"] == 252.75  # (250.5 + 255.0) / 2
+    assert power_stats["min"] == 250.5
+    assert power_stats["max"] == 255.0
+    assert power_stats["latest"] == 255.0
+    assert power_stats["count"] == 2
+
+
+def test_calculate_metrics_empty_data():
+    """Test calculate_metrics function with empty data"""
+    import json
+    
+    test_data = {
+        "Empty Metric": []
+    }
+    
+    metrics_json = json.dumps(test_data)
+    result = tools.calculate_metrics(metrics_json)
+    
+    text = _texts(result)[0]
+    response_data = json.loads(text)
+    calculated = response_data["calculated_metrics"]
+    
+    empty_stats = calculated["Empty Metric"]
+    assert empty_stats["avg"] is None
+    assert empty_stats["min"] is None
+    assert empty_stats["max"] is None
+    assert empty_stats["latest"] is None
+    assert empty_stats["count"] == 0
+
+
+def test_calculate_metrics_invalid_json():
+    """Test calculate_metrics function with invalid JSON"""
+    result = tools.calculate_metrics("invalid json")
+    
+    text = _texts(result)[0]
+    assert "Error: Invalid JSON format" in text
+
+
+def test_calculate_metrics_invalid_data_format():
+    """Test calculate_metrics function with invalid data points"""
+    import json
+    
+    test_data = {
+        "Invalid Metric": [
+            {"timestamp": "2024-01-01T10:00:00"},  # Missing value
+            {"value": "not_a_number", "timestamp": "2024-01-01T10:01:00"},  # Invalid value
+            {"timestamp": "2024-01-01T10:02:00", "value": 45.2}  # Valid point
+        ]
+    }
+    
+    metrics_json = json.dumps(test_data)
+    result = tools.calculate_metrics(metrics_json)
+    
+    text = _texts(result)[0]
+    response_data = json.loads(text)
+    calculated = response_data["calculated_metrics"]
+    
+    # Should only count the valid data point
+    stats = calculated["Invalid Metric"]
+    assert stats["avg"] == 45.2
+    assert stats["count"] == 1
+
+
+def test_analyze_vllm_with_structured_data():
+    """Test that analyze_vllm returns structured data in the response"""
+    import pandas as pd
+    from datetime import datetime
+    
+    with patch("src.mcp_server.tools.observability_vllm_tools.get_vllm_metrics", return_value={"GPU Temperature (°C)": "query1"}):
+        with patch("src.mcp_server.tools.observability_vllm_tools.extract_time_range_with_info", return_value=(1, 2, {})):
+            with patch("src.mcp_server.tools.observability_vllm_tools.build_prompt", return_value="TEST_PROMPT"):
+                with patch("src.mcp_server.tools.observability_vllm_tools.summarize_with_llm", return_value="TEST_SUMMARY"):
+                    with patch("src.mcp_server.tools.observability_vllm_tools.fetch_metrics") as mock_fetch:
+                        # Create mock DataFrame with realistic data
+                        mock_df = pd.DataFrame({
+                            "timestamp": [datetime(2024, 1, 1, 10, 0), datetime(2024, 1, 1, 10, 1)],
+                            "value": [45.2, 46.1]
+                        })
+                        mock_fetch.return_value = mock_df
+                        
+                        result = tools.analyze_vllm("test-model", "test-summarizer", time_range="last 1h")
+                        
+                        text = _texts(result)[0]
+                        
+                        # Check that structured data is included
+                        assert "STRUCTURED_DATA:" in text
+                        
+                        # Extract and parse the structured data
+                        structured_start = text.find("STRUCTURED_DATA:") + len("STRUCTURED_DATA:")
+                        json_data = text[structured_start:].strip()
+                        
+                        import json
+                        structured = json.loads(json_data)
+                        
+                        assert "health_prompt" in structured
+                        assert "llm_summary" in structured
+                        assert "metrics" in structured
+                        
+                        assert structured["health_prompt"] == "TEST_PROMPT"
+                        assert structured["llm_summary"] == "TEST_SUMMARY"
+                        
+                        # Check metrics structure
+                        metrics = structured["metrics"]
+                        assert "GPU Temperature (°C)" in metrics
+                        
+                        data_points = metrics["GPU Temperature (°C)"]
+                        assert len(data_points) == 2
+                        assert data_points[0]["value"] == 45.2
+                        assert data_points[1]["value"] == 46.1
+
+
+@patch("src.mcp_server.tools.observability_vllm_tools.get_vllm_metrics")
+def test_get_vllm_metrics_tool_success(mock_get_vllm_metrics):
+    """Test get_vllm_metrics_tool with successful response"""
+    mock_get_vllm_metrics.return_value = {
+        "GPU Temperature (°C)": "avg(DCGM_FI_DEV_GPU_TEMP)",
+        "P95 Latency (s)": "vllm:e2e_request_latency_seconds_sum",
+        "Requests Running": "vllm:num_requests_running"
+    }
+    
+    result = tools.get_vllm_metrics_tool()
+    text = "\n".join(_texts(result))
+    
+    assert "Available vLLM Metrics (3 total):" in text
+    assert "GPU Temperature (°C)" in text
+    assert "avg(DCGM_FI_DEV_GPU_TEMP)" in text
+    assert "P95 Latency (s)" in text
+    assert "vllm:e2e_request_latency_seconds_sum" in text
+    assert "Requests Running" in text
+    assert "vllm:num_requests_running" in text
+    assert "📊 **GPU Metrics:**" in text
+    assert "🚀 **vLLM Performance Metrics:**" in text
+
+
+@patch("src.mcp_server.tools.observability_vllm_tools.get_vllm_metrics")
+def test_get_vllm_metrics_tool_empty(mock_get_vllm_metrics):
+    """Test get_vllm_metrics_tool with empty response"""
+    mock_get_vllm_metrics.return_value = {}
+    
+    result = tools.get_vllm_metrics_tool()
+    texts = _texts(result)
+    
+    assert "No vLLM metrics are currently available" in "\n".join(texts)
+
+
+@patch("src.mcp_server.tools.observability_vllm_tools.get_vllm_metrics")
+def test_get_vllm_metrics_tool_error(mock_get_vllm_metrics):
+    """Test get_vllm_metrics_tool with error"""
+    mock_get_vllm_metrics.side_effect = Exception("Connection error")
+    
+    result = tools.get_vllm_metrics_tool()
+    texts = _texts(result)
+    
+    assert "Error retrieving vLLM metrics: Connection error" in "\n".join(texts)
 
 

--- a/tests/ui/__init__.py
+++ b/tests/ui/__init__.py
@@ -1,0 +1,1 @@
+# UI tests package

--- a/tests/ui/test_mcp_client_helper.py
+++ b/tests/ui/test_mcp_client_helper.py
@@ -1,0 +1,393 @@
+"""Tests for UI MCP client helper functions."""
+
+import pytest
+from unittest.mock import patch, MagicMock
+import json
+import sys
+import os
+
+# Add src to path to import the UI modules
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), "../../src"))
+
+# Import the module under test
+import ui.mcp_client_helper as mcp_helper
+
+
+class TestMCPClientHelper:
+    """Test MCP client helper functions"""
+
+    @pytest.fixture
+    def mock_mcp_client(self):
+        """Mock MCP client for testing"""
+        mock_client = MagicMock()
+        mock_client.check_server_health.return_value = True
+        return mock_client
+
+    @pytest.fixture
+    def sample_mcp_response(self):
+        """Sample MCP response format"""
+        return [{"type": "text", "text": "Sample response text"}]
+
+    def test_parse_list_response_success(self):
+        """Test successful parsing of list response"""
+        test_result = [{"type": "text", "text": "Available items:\n• Item 1\n• Item 2\n• Item 3"}]
+        
+        client = mcp_helper.MCPClientHelper("http://test")
+        items = client.parse_list_response(test_result, "•")
+        
+        assert len(items) == 3
+        assert "Item 1" in items
+        assert "Item 2" in items
+        assert "Item 3" in items
+
+    def test_parse_list_response_empty(self):
+        """Test parsing empty list response"""
+        test_result = [{"type": "text", "text": "No items found"}]
+        
+        client = mcp_helper.MCPClientHelper("http://test")
+        items = client.parse_list_response(test_result, "•")
+        
+        assert len(items) == 0
+
+    def test_parse_list_response_nested_json(self):
+        """Test parsing response with nested JSON"""
+        # Create a simple test with escaped newlines like what actually happens
+        test_result = [{"type": "text", "text": "Items:\\n• Dev\\n• Main\\n• Test"}]
+        
+        client = mcp_helper.MCPClientHelper("http://test")
+        items = client.parse_list_response(test_result, "•")
+        
+        assert len(items) == 3
+        assert "Dev" in items
+
+    @patch('ui.mcp_client_helper.mcp_client')
+    def test_get_namespaces_mcp_success(self, mock_client):
+        """Test successful namespace retrieval"""
+        mock_client.check_server_health.return_value = True
+        mock_client.call_tool_sync.return_value = [
+            {"type": "text", "text": "Monitored Namespaces (3 total):\n• dev\n• main\n• test"}
+        ]
+        
+        # Mock the parse_list_response method
+        mock_client.parse_list_response.return_value = ["dev", "main", "test"]
+        
+        namespaces = mcp_helper.get_namespaces_mcp()
+        
+        assert len(namespaces) == 3
+        assert "dev" in namespaces
+        assert "main" in namespaces
+        assert "test" in namespaces
+
+    @patch('ui.mcp_client_helper.mcp_client')
+    def test_get_models_mcp_success(self, mock_client):
+        """Test successful model retrieval"""
+        mock_client.check_server_health.return_value = True
+        mock_client.call_tool_sync.return_value = [
+            {"type": "text", "text": "Available AI Models (2 total):\n• dev | llama-model\n• main | gpt-model"}
+        ]
+        
+        # Mock the parse_list_response method
+        mock_client.parse_list_response.return_value = ["dev | llama-model", "main | gpt-model"]
+        
+        models = mcp_helper.get_models_mcp()
+        
+        assert len(models) == 2
+        assert "dev | llama-model" in models
+        assert "main | gpt-model" in models
+
+    @patch('ui.mcp_client_helper.mcp_client')
+    def test_get_model_config_mcp_success(self, mock_client):
+        """Test successful model config retrieval"""
+        config_text = """Available Model Config (2 total):
+
+• meta-llama/Llama-3.2-3B-Instruct
+  - external: False
+  - requiresApiKey: False
+  - serviceName: llama-service
+
+• openai/gpt-4o-mini
+  - external: True
+  - requiresApiKey: True
+  - apiUrl: https://api.openai.com/v1/chat/completions"""
+
+        mock_client.check_server_health.return_value = True
+        mock_client.call_tool_sync.return_value = [{"type": "text", "text": config_text}]
+        
+        config = mcp_helper.get_model_config_mcp()
+        
+        assert isinstance(config, dict)
+        assert "meta-llama/Llama-3.2-3B-Instruct" in config
+        assert "openai/gpt-4o-mini" in config
+        
+        llama_config = config["meta-llama/Llama-3.2-3B-Instruct"]
+        assert llama_config["external"] is False
+        assert llama_config["requiresApiKey"] is False
+        assert llama_config["serviceName"] == "llama-service"
+
+    def test_parse_model_config_text(self):
+        """Test parsing model config text format"""
+        config_text = """Available Model Config (1 total):
+
+• test-model
+  - external: True
+  - requiresApiKey: False
+  - cost: {"input": 0.01, "output": 0.02}"""
+
+        config = mcp_helper.parse_model_config_text(config_text)
+        
+        assert "test-model" in config
+        model_config = config["test-model"]
+        assert model_config["external"] is True
+        assert model_config["requiresApiKey"] is False
+        assert isinstance(model_config["cost"], dict)
+
+    @patch('ui.mcp_client_helper.mcp_client')
+    def test_calculate_metrics_mcp_success(self, mock_client):
+        """Test successful metrics calculation via MCP"""
+        mock_client.check_server_health.return_value = True
+        
+        # Mock response with structured JSON
+        response_data = {
+            "calculated_metrics": {
+                "GPU Temperature (°C)": {
+                    "avg": 45.5,
+                    "min": 44.0,
+                    "max": 47.0,
+                    "latest": 46.0,
+                    "count": 3
+                }
+            }
+        }
+        
+        mock_client.call_tool_sync.return_value = [
+            {"type": "text", "text": json.dumps(response_data)}
+        ]
+        
+        test_metrics = {
+            "GPU Temperature (°C)": [
+                {"timestamp": "2024-01-01T10:00:00", "value": 45.0},
+                {"timestamp": "2024-01-01T10:01:00", "value": 46.0}
+            ]
+        }
+        
+        result = mcp_helper.calculate_metrics_mcp(test_metrics)
+        
+        assert "GPU Temperature (°C)" in result
+        stats = result["GPU Temperature (°C)"]
+        assert stats["avg"] == 45.5
+        assert stats["count"] == 3
+
+    @patch('ui.mcp_client_helper.mcp_client')
+    def test_calculate_metrics_mcp_server_down(self, mock_client):
+        """Test calculate_metrics when MCP server is down (fallback to local)"""
+        mock_client.check_server_health.return_value = False
+        
+        test_metrics = {
+            "GPU Temperature (°C)": [
+                {"timestamp": "2024-01-01T10:00:00", "value": 45.0},
+                {"timestamp": "2024-01-01T10:01:00", "value": 46.0}
+            ]
+        }
+        
+        # The function should fallback to local calculation automatically
+        result = mcp_helper.calculate_metrics_mcp(test_metrics)
+        
+        # Should use local fallback calculation
+        assert "GPU Temperature (°C)" in result
+        stats = result["GPU Temperature (°C)"]
+        assert stats["avg"] == 45.5  # (45.0 + 46.0) / 2
+        assert stats["count"] == 2
+
+    def test_calculate_metrics_locally(self):
+        """Test local metrics calculation fallback"""
+        test_metrics = {
+            "GPU Temperature (°C)": [
+                {"timestamp": "2024-01-01T10:00:00", "value": 45.0},
+                {"timestamp": "2024-01-01T10:01:00", "value": 46.0},
+                {"timestamp": "2024-01-01T10:02:00", "value": 47.0}
+            ],
+            "Empty Metric": [],
+            "Invalid Metric": [
+                {"timestamp": "2024-01-01T10:00:00"},  # Missing value
+                {"timestamp": "2024-01-01T10:01:00", "value": "invalid"}  # Invalid value
+            ]
+        }
+        
+        result = mcp_helper.calculate_metrics_locally(test_metrics)
+        
+        # Check valid metric
+        temp_stats = result["GPU Temperature (°C)"]
+        assert temp_stats["avg"] == 46.0  # (45 + 46 + 47) / 3
+        assert temp_stats["min"] == 45.0
+        assert temp_stats["max"] == 47.0
+        assert temp_stats["latest"] == 47.0
+        assert temp_stats["count"] == 3
+        
+        # Check empty metric
+        empty_stats = result["Empty Metric"]
+        assert empty_stats["avg"] is None
+        assert empty_stats["count"] == 0
+        
+        # Check invalid metric
+        invalid_stats = result["Invalid Metric"]
+        assert invalid_stats["avg"] is None
+        assert invalid_stats["count"] == 0
+
+    @patch('ui.mcp_client_helper.mcp_client')
+    def test_analyze_vllm_mcp_success(self, mock_client):
+        """Test successful vLLM analysis via MCP"""
+        mock_client.check_server_health.return_value = True
+        
+        # Mock response with structured data
+        structured_data = {
+            "health_prompt": "Test prompt",
+            "llm_summary": "Test summary",
+            "metrics": {
+                "GPU Temperature (°C)": [
+                    {"timestamp": "2024-01-01T10:00:00", "value": 45.0}
+                ]
+            }
+        }
+        
+        response_text = f"Analysis complete\n\nSTRUCTURED_DATA:\n{json.dumps(structured_data)}"
+        mock_client.call_tool_sync.return_value = [{"type": "text", "text": response_text}]
+        
+        result = mcp_helper.analyze_vllm_mcp(
+            model_name="test | model",
+            summarize_model_id="summarizer",
+            start_ts=1640995200,
+            end_ts=1640995800,
+            api_key=None
+        )
+        
+        assert result["health_prompt"] == "Test prompt"
+        assert result["llm_summary"] == "Test summary"
+        assert "GPU Temperature (°C)" in result["metrics"]
+        assert len(result["metrics"]["GPU Temperature (°C)"]) == 1
+
+    def test_parse_analyze_response_structured_data(self):
+        """Test parsing analyze response with structured data"""
+        structured_data = {
+            "health_prompt": "Test prompt",
+            "llm_summary": "Test summary",
+            "metrics": {"temp": [{"value": 45}]}
+        }
+        
+        response_text = f"Model analysis\n\nSTRUCTURED_DATA:\n{json.dumps(structured_data)}"
+        
+        result = mcp_helper.parse_analyze_response(response_text)
+        
+        assert result["health_prompt"] == "Test prompt"
+        assert result["llm_summary"] == "Test summary"
+        assert "temp" in result["metrics"]
+
+    def test_parse_analyze_response_fallback(self):
+        """Test parsing analyze response without structured data (fallback mode)"""
+        response_text = """Model: test-model
+
+Prompt Used:
+Test prompt content
+
+Summary:
+**Performance Summary**
+Test summary content
+
+Metrics Preview:
+- GPU TEMPERATURE: 45.0"""
+        
+        result = mcp_helper.parse_analyze_response(response_text)
+        
+        assert "Test prompt content" in result["health_prompt"]
+        assert "Test summary content" in result["llm_summary"]
+        assert "gpu_temp_analyzed" in result["metrics"]
+        assert result["metrics"]["gpu_temp_analyzed"] == "true"
+
+    @patch('ui.mcp_client_helper.mcp_client')
+    def test_mcp_client_server_health_check(self, mock_client):
+        """Test MCP client health check functionality"""
+        # Test healthy server
+        mock_client.check_server_health.return_value = True
+        assert mcp_helper.get_namespaces_mcp() is not None
+        
+        # Test unhealthy server
+        mock_client.check_server_health.return_value = False
+        result = mcp_helper.get_namespaces_mcp()
+        assert result == []
+
+    def test_mcp_client_helper_initialization(self):
+        """Test MCP client helper initialization"""
+        client = mcp_helper.MCPClientHelper("http://test:8080")
+        # The MCPClientHelper stores URL info but may not expose base_url directly
+        # Test that it can be created without error
+        assert client is not None
+        assert hasattr(client, 'check_server_health')
+
+
+    @patch.object(mcp_helper.mcp_client, 'check_server_health', return_value=True)
+    @patch.object(mcp_helper.mcp_client, 'call_tool_sync')
+    def test_get_vllm_metrics_mcp_success(self, mock_call_tool, mock_health_check):
+        """Test get_vllm_metrics_mcp with successful response"""
+        mock_call_tool.return_value = [{
+            "type": "text",
+            "text": "Available vLLM Metrics (2 total):\n\n📊 **GPU Metrics:**\n• GPU Temperature (°C)\n  Query: `avg(DCGM_FI_DEV_GPU_TEMP)`\n\n🚀 **vLLM Performance Metrics:**\n• P95 Latency (s)\n  Query: `vllm:e2e_request_latency_seconds_sum`\n\n"
+        }]
+        
+        result = mcp_helper.get_vllm_metrics_mcp()
+        
+        mock_call_tool.assert_called_once_with("get_vllm_metrics_tool", {})
+        assert isinstance(result, dict)
+        assert len(result) == 2
+        assert "GPU Temperature (°C)" in result
+        assert result["GPU Temperature (°C)"] == "avg(DCGM_FI_DEV_GPU_TEMP)"
+        assert "P95 Latency (s)" in result
+        assert result["P95 Latency (s)"] == "vllm:e2e_request_latency_seconds_sum"
+
+
+    @patch.object(mcp_helper.mcp_client, 'check_server_health', return_value=False)
+    def test_get_vllm_metrics_mcp_server_down(self, mock_health_check):
+        """Test get_vllm_metrics_mcp when server is down"""
+        result = mcp_helper.get_vllm_metrics_mcp()
+        
+        assert isinstance(result, dict)
+        assert len(result) == 0
+
+
+    def test_parse_vllm_metrics_text(self):
+        """Test parse_vllm_metrics_text function"""
+        sample_text = """Available vLLM Metrics (3 total):
+
+📊 **GPU Metrics:**
+• GPU Temperature (°C)
+  Query: `avg(DCGM_FI_DEV_GPU_TEMP)`
+
+• GPU Power Usage (Watts)
+  Query: `avg(DCGM_FI_DEV_POWER_USAGE)`
+
+🚀 **vLLM Performance Metrics:**
+• P95 Latency (s)
+  Query: `vllm:e2e_request_latency_seconds_sum`
+
+**Summary:**
+- GPU Metrics: 2
+- vLLM Performance: 1
+- Total: 3
+"""
+        
+        result = mcp_helper.parse_vllm_metrics_text(sample_text)
+        
+        assert isinstance(result, dict)
+        assert len(result) == 3
+        assert "GPU Temperature (°C)" in result
+        assert result["GPU Temperature (°C)"] == "avg(DCGM_FI_DEV_GPU_TEMP)"
+        assert "GPU Power Usage (Watts)" in result
+        assert result["GPU Power Usage (Watts)"] == "avg(DCGM_FI_DEV_POWER_USAGE)"
+        assert "P95 Latency (s)" in result
+        assert result["P95 Latency (s)"] == "vllm:e2e_request_latency_seconds_sum"
+
+
+    def test_parse_vllm_metrics_text_empty(self):
+        """Test parse_vllm_metrics_text with empty text"""
+        result = mcp_helper.parse_vllm_metrics_text("")
+        
+        assert isinstance(result, dict)
+        assert len(result) == 0


### PR DESCRIPTION
## Changes

✅ Page 1: "vLLM Metric Summarizer" - FULLY MCP CONVERTED to MCP Server
- get_vllm_metrics() ✅ MCP
- get_models() ✅ MCP  
- get_namespaces() ✅ MCP
- get_model_config() ✅ MCP
- analyze_vllm() ✅ MCP
- calculate_metrics() ✅ MCP

<img width="1846" height="927" alt="Screenshot 2025-09-08 at 3 11 40 PM" src="https://github.com/user-attachments/assets/f549199d-06a2-4a0a-a486-812f89c9e4fd" />

## Checklist

- [x] Verify on the cluster
- [ ] Update tests if applicable and run `pytest`
- [x] Add screenshots (if applicable)
- [ ] Update readme (if applicable)