### PR TITLE
display correct branch info

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -34,13 +34,13 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v4
         with:
-          ref: ${{ github.event.workflow_run.head_branch }}
+          ref: ${{ github.event_name == 'workflow_run' && github.event.workflow_run.head_branch || github.ref_name }}
 
       - name: Show branch and commit info
         run: |
           echo "::group::Repository Information"
-          echo "Branch: ${{ github.ref_name }}"
-          echo "Commit SHA: ${{ github.sha }}"
+          echo "Checked out branch: $(git branch --show-current)"
+          echo "Target ref: ${{ github.event_name == 'workflow_run' && github.event.workflow_run.head_branch || github.ref_name }}"
           echo "Event: ${{ github.event_name }}"
           echo "Repository: ${{ github.repository }}"
           echo "Actor: ${{ github.actor }}"


### PR DESCRIPTION
## Changes

* The workflow will now correctly display the branch that was actually checked out, resolving the discrepancy between the checkout step and the branch display step.
* Tested in my personal repo and shows correct branch info when PR is merged into `dev` branch or the `main` branch.

### Screenshots:
<img width="1258" height="1208" alt="Screenshot 2025-09-11 at 3 30 01 PM" src="https://github.com/user-attachments/assets/296327bc-f875-44a2-86ba-b9ad3e2d7621" />


## Checklist

- [ ] Verify on the cluster
- [ ] Update tests if applicable and run `pytest`
- [x] Add screenshots (if applicable)
- [ ] Update readme (if applicable)