### PR TITLE
Cherry-pick: display correct branch info (PR #102)

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -34,13 +34,13 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v4
         with:
-          ref: ${{ github.event.workflow_run.head_branch }}
+          ref: ${{ github.event_name == 'workflow_run' && github.event.workflow_run.head_branch || github.ref_name }}
 
       - name: Show branch and commit info
         run: |
           echo "::group::Repository Information"
-          echo "Branch: ${{ github.ref_name }}"
-          echo "Commit SHA: ${{ github.sha }}"
+          echo "Checked out branch: $(git branch --show-current)"
+          echo "Target ref: ${{ github.event_name == 'workflow_run' && github.event.workflow_run.head_branch || github.ref_name }}"
           echo "Event: ${{ github.event_name }}"
           echo "Repository: ${{ github.repository }}"
           echo "Actor: ${{ github.actor }}"


### PR DESCRIPTION
## Summary
Cherry-pick of PR #102 to main branch.

* The workflow will now correctly display the branch that was actually checked out, resolving the discrepancy between the checkout step and the branch display step.
* This fix ensures that the branch information displayed is accurate for both dev and main branches.

## Original PR
This is a cherry-pick of #102 which was merged into the dev branch.

## Test plan
- [ ] Verify on the cluster that branch info is displayed correctly
- [x] Cherry-pick applied cleanly to main branch
