### PR TITLE
fix: tool loop detection false-positive on parallel tool calls

### DIFF
--- a/src/chatbots/anthropic_bot.py
+++ b/src/chatbots/anthropic_bot.py
@@ -152,16 +152,15 @@ class AnthropicChatBot(BaseChatBot):
                     tool_count = sum(1 for block in response.content if block.type == "tool_use")
                     logger.info(f"🤖 Anthropic requesting {tool_count} tool(s)")
 
+                    # Collect tool names for iteration-level loop detection
+                    tool_names_this_iteration = {
+                        block.name for block in response.content if block.type == "tool_use"
+                    }
+
                     tool_results = []
-                    tool_loop_detected = False
                     for content_block in response.content:
                         if content_block.type == "tool_use":
                             tool_name = content_block.name
-
-                            if self._check_tool_loop(tool_name, consecutive_tool_tracker):
-                                tool_loop_detected = True
-                                break
-
                             tool_args = content_block.input
                             tool_id = content_block.id
 
@@ -177,7 +176,7 @@ class AnthropicChatBot(BaseChatBot):
                                 "content": tool_result
                             })
 
-                    if tool_loop_detected:
+                    if self._check_tool_loop(tool_names_this_iteration, consecutive_tool_tracker):
                         return (
                             "I got stuck in a loop calling the same tool repeatedly. "
                             "Please try rephrasing your question or being more specific."

--- a/src/chatbots/anthropic_bot.py
+++ b/src/chatbots/anthropic_bot.py
@@ -157,6 +157,12 @@ class AnthropicChatBot(BaseChatBot):
                         block.name for block in response.content if block.type == "tool_use"
                     }
 
+                    if self._check_tool_loop(tool_names_this_iteration, consecutive_tool_tracker):
+                        return (
+                            "I got stuck in a loop calling the same tool repeatedly. "
+                            "Please try rephrasing your question or being more specific."
+                        )
+
                     tool_results = []
                     for content_block in response.content:
                         if content_block.type == "tool_use":
@@ -175,12 +181,6 @@ class AnthropicChatBot(BaseChatBot):
                                 "tool_use_id": tool_id,
                                 "content": tool_result
                             })
-
-                    if self._check_tool_loop(tool_names_this_iteration, consecutive_tool_tracker):
-                        return (
-                            "I got stuck in a loop calling the same tool repeatedly. "
-                            "Please try rephrasing your question or being more specific."
-                        )
 
                     # Add tool results to conversation
                     messages.append({

--- a/src/chatbots/base.py
+++ b/src/chatbots/base.py
@@ -127,33 +127,45 @@ class BaseChatBot(ABC):
             return self.model_name.split("/", 1)[1]
         return self.model_name
 
-    # Maximum number of consecutive calls to the same tool before breaking
-    # the loop. Legitimate multi-call patterns (e.g., execute_promql for
-    # power then temperature) use at most 3 consecutive same-tool calls.
+    # Maximum number of consecutive iterations calling the same single tool
+    # before breaking the loop. Tracked at the iteration level so that
+    # parallel calls to the same tool within one response don't false-positive.
     _MAX_CONSECUTIVE_SAME_TOOL = 5
 
-    def _check_tool_loop(self, tool_name: str, consecutive_tool_tracker: dict) -> bool:
-        """Check if the same tool has been called too many times consecutively.
+    def _check_tool_loop(self, tool_names_this_iteration: set, consecutive_tool_tracker: dict) -> bool:
+        """Check if the same tool is being called across consecutive iterations.
+
+        Tracks at the iteration level, not individual tool-call level.
+        A single iteration calling the same tool multiple times (parallel queries)
+        is legitimate. The loop detector only fires when consecutive *iterations*
+        each call the same single tool.
 
         Args:
-            tool_name: The tool being called this iteration.
+            tool_names_this_iteration: Set of tool names called in this iteration.
             consecutive_tool_tracker: Dict with 'name' and 'count' keys,
-                mutated in place to track state across calls.
+                mutated in place to track state across iterations.
 
         Returns:
             True if the tool loop threshold has been reached (caller should break).
         """
-        if tool_name == consecutive_tool_tracker.get("name"):
-            consecutive_tool_tracker["count"] += 1
+        if len(tool_names_this_iteration) == 1:
+            tool_name = next(iter(tool_names_this_iteration))
+            if tool_name == consecutive_tool_tracker.get("name"):
+                consecutive_tool_tracker["count"] += 1
+            else:
+                consecutive_tool_tracker["name"] = tool_name
+                consecutive_tool_tracker["count"] = 1
         else:
-            consecutive_tool_tracker["name"] = tool_name
-            consecutive_tool_tracker["count"] = 1
+            # Multiple different tools in one iteration — not a loop
+            consecutive_tool_tracker["name"] = None
+            consecutive_tool_tracker["count"] = 0
 
         if consecutive_tool_tracker["count"] >= self._MAX_CONSECUTIVE_SAME_TOOL:
             logger.warning(
-                "Tool loop detected: %s called %d times consecutively. "
+                "Tool loop detected: %s called in %d consecutive iterations. "
                 "Breaking loop.",
-                tool_name, consecutive_tool_tracker["count"],
+                consecutive_tool_tracker.get("name"),
+                consecutive_tool_tracker["count"],
             )
             return True
         return False

--- a/src/chatbots/google_bot.py
+++ b/src/chatbots/google_bot.py
@@ -386,15 +386,21 @@ class GoogleChatBot(BaseChatBot):
                                 if has_nudge_function_calls:
                                     # Process function calls from nudge response
                                     parts = nudge_parts
+                                    tool_names_nudge = {
+                                        p.function_call.name for p in parts
+                                        if hasattr(p, 'function_call') and p.function_call
+                                    }
+                                    if self._check_tool_loop(tool_names_nudge, consecutive_tool_tracker):
+                                        return (
+                                            "I got stuck in a loop calling the same tool repeatedly. "
+                                            "Please try rephrasing your question or being more specific."
+                                        )
                                     function_responses = []
                                     for part in parts:
                                         if hasattr(part, 'function_call') and part.function_call:
                                             func_call = part.function_call
                                             tool_name = func_call.name
                                             tool_args = self._convert_proto_to_native(dict(func_call.args))
-
-                                            if self._check_tool_loop(tool_name, consecutive_tool_tracker):
-                                                break
 
                                             if progress_callback:
                                                 progress_callback(f"🔧 Using tool: {tool_name}")

--- a/src/chatbots/google_bot.py
+++ b/src/chatbots/google_bot.py
@@ -309,17 +309,18 @@ class GoogleChatBot(BaseChatBot):
                     tool_count = sum(1 for p in parts if hasattr(p, 'function_call') and p.function_call)
                     logger.info(f"🤖 Google Gemini requesting {tool_count} tool(s)")
 
+                    # Collect tool names for iteration-level loop detection
+                    tool_names_this_iteration = {
+                        p.function_call.name for p in parts
+                        if hasattr(p, 'function_call') and p.function_call
+                    }
+
                     # Build function responses for next iteration
                     function_responses = []  # Clear previous responses
-                    tool_loop_detected = False
                     for part in parts:
                         if hasattr(part, 'function_call') and part.function_call:
                             func_call = part.function_call
                             tool_name = func_call.name
-
-                            if self._check_tool_loop(tool_name, consecutive_tool_tracker):
-                                tool_loop_detected = True
-                                break
 
                             # Convert proto args to native Python types (dict with proto values -> dict with native values)
                             tool_args = self._convert_proto_to_native(dict(func_call.args))
@@ -340,7 +341,7 @@ class GoogleChatBot(BaseChatBot):
                                 )
                             )
 
-                    if tool_loop_detected:
+                    if self._check_tool_loop(tool_names_this_iteration, consecutive_tool_tracker):
                         return (
                             "I got stuck in a loop calling the same tool repeatedly. "
                             "Please try rephrasing your question or being more specific."

--- a/src/chatbots/google_bot.py
+++ b/src/chatbots/google_bot.py
@@ -315,8 +315,14 @@ class GoogleChatBot(BaseChatBot):
                         if hasattr(p, 'function_call') and p.function_call
                     }
 
+                    if self._check_tool_loop(tool_names_this_iteration, consecutive_tool_tracker):
+                        return (
+                            "I got stuck in a loop calling the same tool repeatedly. "
+                            "Please try rephrasing your question or being more specific."
+                        )
+
                     # Build function responses for next iteration
-                    function_responses = []  # Clear previous responses
+                    function_responses = []
                     for part in parts:
                         if hasattr(part, 'function_call') and part.function_call:
                             func_call = part.function_call
@@ -340,12 +346,6 @@ class GoogleChatBot(BaseChatBot):
                                     )
                                 )
                             )
-
-                    if self._check_tool_loop(tool_names_this_iteration, consecutive_tool_tracker):
-                        return (
-                            "I got stuck in a loop calling the same tool repeatedly. "
-                            "Please try rephrasing your question or being more specific."
-                        )
 
                     logger.info(f"Prepared {len(function_responses)} function response(s) for next iteration")
                     # Continue loop to send function responses

--- a/src/chatbots/llama_bot.py
+++ b/src/chatbots/llama_bot.py
@@ -476,6 +476,12 @@ class LlamaChatBot(BaseChatBot):
                         tc.function.name for tc in message.tool_calls
                     }
 
+                    if self._check_tool_loop(tool_names_this_iteration, consecutive_tool_tracker):
+                        return (
+                            "I got stuck in a loop calling the same tool repeatedly. "
+                            "Please try rephrasing your question or being more specific."
+                        )
+
                     tool_results = []
                     for tool_call in message.tool_calls:
                         tool_name = tool_call.function.name
@@ -499,12 +505,6 @@ class LlamaChatBot(BaseChatBot):
                             "tool_call_id": tool_id,
                             "content": tool_result
                         })
-
-                    if self._check_tool_loop(tool_names_this_iteration, consecutive_tool_tracker):
-                        return (
-                            "I got stuck in a loop calling the same tool repeatedly. "
-                            "Please try rephrasing your question or being more specific."
-                        )
 
                     # Add tool results to conversation
                     messages.extend(tool_results)

--- a/src/chatbots/llama_bot.py
+++ b/src/chatbots/llama_bot.py
@@ -471,8 +471,12 @@ class LlamaChatBot(BaseChatBot):
                     has_called_tools = True
                     logger.info(f"🤖 LlamaStack requesting {len(message.tool_calls)} tool(s)")
 
+                    # Collect tool names for iteration-level loop detection
+                    tool_names_this_iteration = {
+                        tc.function.name for tc in message.tool_calls
+                    }
+
                     tool_results = []
-                    tool_loop_detected = False
                     for tool_call in message.tool_calls:
                         tool_name = tool_call.function.name
                         tool_args_str = tool_call.function.arguments
@@ -483,10 +487,6 @@ class LlamaChatBot(BaseChatBot):
                             tool_args = json.loads(tool_args_str)
                         except json.JSONDecodeError:
                             tool_args = {}
-
-                        if self._check_tool_loop(tool_name, consecutive_tool_tracker):
-                            tool_loop_detected = True
-                            break
 
                         if progress_callback:
                             progress_callback(f"🔧 Using tool: {tool_name}")
@@ -500,7 +500,7 @@ class LlamaChatBot(BaseChatBot):
                             "content": tool_result
                         })
 
-                    if tool_loop_detected:
+                    if self._check_tool_loop(tool_names_this_iteration, consecutive_tool_tracker):
                         return (
                             "I got stuck in a loop calling the same tool repeatedly. "
                             "Please try rephrasing your question or being more specific."

--- a/src/chatbots/openai_bot.py
+++ b/src/chatbots/openai_bot.py
@@ -179,6 +179,12 @@ Wrong flow:
                         tc.function.name for tc in message.tool_calls
                     }
 
+                    if self._check_tool_loop(tool_names_this_iteration, consecutive_tool_tracker):
+                        return (
+                            "I got stuck in a loop calling the same tool repeatedly. "
+                            "Please try rephrasing your question or being more specific."
+                        )
+
                     tool_results = []
                     for tool_call in message.tool_calls:
                         tool_name = tool_call.function.name
@@ -202,12 +208,6 @@ Wrong flow:
                             "tool_call_id": tool_id,
                             "content": tool_result
                         })
-
-                    if self._check_tool_loop(tool_names_this_iteration, consecutive_tool_tracker):
-                        return (
-                            "I got stuck in a loop calling the same tool repeatedly. "
-                            "Please try rephrasing your question or being more specific."
-                        )
 
                     # Add tool results to conversation
                     messages.extend(tool_results)

--- a/src/chatbots/openai_bot.py
+++ b/src/chatbots/openai_bot.py
@@ -174,8 +174,12 @@ Wrong flow:
                 if finish_reason == 'tool_calls' and message.tool_calls:
                     logger.info(f"🤖 OpenAI requesting {len(message.tool_calls)} tool(s)")
 
+                    # Collect tool names for iteration-level loop detection
+                    tool_names_this_iteration = {
+                        tc.function.name for tc in message.tool_calls
+                    }
+
                     tool_results = []
-                    tool_loop_detected = False
                     for tool_call in message.tool_calls:
                         tool_name = tool_call.function.name
                         tool_args_str = tool_call.function.arguments
@@ -186,10 +190,6 @@ Wrong flow:
                             tool_args = json.loads(tool_args_str)
                         except json.JSONDecodeError:
                             tool_args = {}
-
-                        if self._check_tool_loop(tool_name, consecutive_tool_tracker):
-                            tool_loop_detected = True
-                            break
 
                         if progress_callback:
                             progress_callback(f"🔧 Using tool: {tool_name}")
@@ -203,7 +203,7 @@ Wrong flow:
                             "content": tool_result
                         })
 
-                    if tool_loop_detected:
+                    if self._check_tool_loop(tool_names_this_iteration, consecutive_tool_tracker):
                         return (
                             "I got stuck in a loop calling the same tool repeatedly. "
                             "Please try rephrasing your question or being more specific."

--- a/tests/mcp_server/test_chatbots.py
+++ b/tests/mcp_server/test_chatbots.py
@@ -1272,42 +1272,47 @@ class TestLlamaGracefulFallback:
 
 
 class TestToolLoopDetection:
-    """Test the consecutive same-tool loop detection in BaseChatBot."""
+    """Test the consecutive same-tool loop detection in BaseChatBot.
+
+    Loop detection operates at the iteration level: each call to
+    _check_tool_loop represents one LLM response (iteration) and receives
+    the *set* of tool names used in that response.
+    """
 
     def test_no_loop_different_tools(self, mock_mcp_tools):
-        """Test that different tools don't trigger loop detection."""
+        """Test that different single-tool iterations don't trigger loop detection."""
         from chatbots import LlamaChatBot
 
         bot = LlamaChatBot(LLAMA_3_1_8B, tool_executor=mock_mcp_tools)
         tracker = {"name": None, "count": 0}
 
-        assert bot._check_tool_loop("execute_promql", tracker) is False
-        assert bot._check_tool_loop("get_label_values", tracker) is False
-        assert bot._check_tool_loop("execute_promql", tracker) is False
+        assert bot._check_tool_loop({"execute_promql"}, tracker) is False
+        assert bot._check_tool_loop({"get_label_values"}, tracker) is False
+        assert bot._check_tool_loop({"execute_promql"}, tracker) is False
         assert tracker["count"] == 1  # Reset on tool change
 
     def test_same_tool_below_threshold(self, mock_mcp_tools):
-        """Test that same tool called < 5 times doesn't trigger."""
+        """Test that same single-tool iterations < 5 times doesn't trigger."""
         from chatbots import LlamaChatBot
 
         bot = LlamaChatBot(LLAMA_3_1_8B, tool_executor=mock_mcp_tools)
         tracker = {"name": None, "count": 0}
 
         for i in range(4):
-            assert bot._check_tool_loop("execute_promql", tracker) is False
+            assert bot._check_tool_loop({"execute_promql"}, tracker) is False
         assert tracker["count"] == 4
 
     def test_same_tool_at_threshold_triggers(self, mock_mcp_tools):
-        """Test that same tool called 5 times triggers loop detection."""
+        """Test that same single-tool iteration 5 times triggers loop detection."""
         from chatbots import LlamaChatBot
 
         bot = LlamaChatBot(LLAMA_3_1_8B, tool_executor=mock_mcp_tools)
         tracker = {"name": None, "count": 0}
 
         for i in range(4):
-            assert bot._check_tool_loop("query_tempo_tool", tracker) is False
-        # 5th call triggers
-        assert bot._check_tool_loop("query_tempo_tool", tracker) is True
+            assert bot._check_tool_loop({"query_tempo_tool"}, tracker) is False
+        # 5th iteration triggers
+        assert bot._check_tool_loop({"query_tempo_tool"}, tracker) is True
 
     def test_counter_resets_on_different_tool(self, mock_mcp_tools):
         """Test that the counter resets when a different tool is called."""
@@ -1316,15 +1321,53 @@ class TestToolLoopDetection:
         bot = LlamaChatBot(LLAMA_3_1_8B, tool_executor=mock_mcp_tools)
         tracker = {"name": None, "count": 0}
 
-        # Call same tool 4 times (just below threshold)
+        # Call same tool in 4 consecutive iterations (just below threshold)
         for i in range(4):
-            bot._check_tool_loop("query_tempo_tool", tracker)
+            bot._check_tool_loop({"query_tempo_tool"}, tracker)
         assert tracker["count"] == 4
 
         # Different tool resets counter
-        bot._check_tool_loop("execute_promql", tracker)
+        bot._check_tool_loop({"execute_promql"}, tracker)
         assert tracker["count"] == 1
         assert tracker["name"] == "execute_promql"
+
+    def test_parallel_same_tool_calls_not_flagged(self, mock_mcp_tools):
+        """Test that one iteration with multiple calls to the same tool is NOT a loop.
+
+        This is the key scenario: Haiku issues 5x execute_promql in a single
+        response for different pod-phase queries. That's one iteration with
+        parallel queries, not 5 consecutive loop iterations.
+        """
+        from chatbots import LlamaChatBot
+
+        bot = LlamaChatBot(LLAMA_3_1_8B, tool_executor=mock_mcp_tools)
+        tracker = {"name": None, "count": 0}
+
+        # One iteration with 5 calls to the same tool — the set has 1 element,
+        # but it's only 1 iteration so count goes to 1, not 5.
+        assert bot._check_tool_loop({"execute_promql"}, tracker) is False
+        assert tracker["count"] == 1
+
+        # A second iteration with different tools resets counter
+        assert bot._check_tool_loop({"execute_promql", "get_label_values"}, tracker) is False
+        assert tracker["count"] == 0
+
+    def test_multi_tool_iteration_resets_counter(self, mock_mcp_tools):
+        """Test that an iteration with multiple different tools resets the counter."""
+        from chatbots import LlamaChatBot
+
+        bot = LlamaChatBot(LLAMA_3_1_8B, tool_executor=mock_mcp_tools)
+        tracker = {"name": None, "count": 0}
+
+        # Build up 4 consecutive same-tool iterations
+        for i in range(4):
+            bot._check_tool_loop({"execute_promql"}, tracker)
+        assert tracker["count"] == 4
+
+        # An iteration with multiple different tools resets the counter
+        bot._check_tool_loop({"execute_promql", "query_tempo_tool"}, tracker)
+        assert tracker["count"] == 0
+        assert tracker["name"] is None
 
     def test_tool_loop_breaks_chat_loop(self, mock_mcp_tools):
         """Test that tool loop detection breaks the chat iteration loop."""
@@ -1332,7 +1375,7 @@ class TestToolLoopDetection:
 
         bot = LlamaChatBot(LLAMA_3_1_8B, tool_executor=mock_mcp_tools)
 
-        # Create 6 responses that all call the same tool
+        # Create 6 responses that each call the same single tool
         def make_tool_response():
             tc = MagicMock()
             tc.id = "call_1"
@@ -1357,7 +1400,7 @@ class TestToolLoopDetection:
 
         result = bot.chat("find traces")
 
-        # Should break after 5 consecutive same-tool calls, not use all 6
+        # Should break after 5 consecutive same-tool iterations, not use all 6
         assert bot.client.chat.completions.create.call_count == 5
         assert "got stuck in a loop" in result
 


### PR DESCRIPTION
## Changes

  - `_check_tool_loop` counted each individual tool call, so a single LLM response with 5 parallel `execute_promql` queries hit the threshold of 5 and falsely triggered loop detection. **Haiku** was especially affected as it tends to batch 5+ PromQL calls for broad questions like "What's the overall health of my cluster?"
  - Changed loop detection to track at the **iteration level** — one check per LLM response instead of per tool call. A single iteration calling the same tool multiple times (parallel queries) is now correctly treated as one iteration, not a loop.

## Screenshots
- **Before the fix**
<img width="1228" height="435" alt="01-overall_health-before" src="https://github.com/user-attachments/assets/201beb4e-1da1-4ee9-a84e-db6e7b421ff2" />

---

- **After the fix**
<img width="1713" height="1674" alt="01-overall_health-after" src="https://github.com/user-attachments/assets/e770703e-bba2-4249-aa2c-0cd7eb4fedb0" />

## Checklist

- [x] Verify on the cluster
- [x] Update tests if applicable and run `make test`
- [x] Add screenshots (if applicable)
- [ ] Update readme (if applicable)