### PR TITLE
fix: prevent version bump workflow from overwriting oauth-proxy image tag

### DIFF
--- a/.github/workflows/update-versions.yml
+++ b/.github/workflows/update-versions.yml
@@ -37,25 +37,37 @@ jobs:
           ref: ${{ inputs.target_branch || github.ref }}
           fetch-depth: 0
 
+      # NOTE: Each sed below targets ONLY the app image tag by matching the
+      # repository line first, then substituting the very next 'tag:' line.
+      # This prevents overwriting unrelated tags (e.g. oauth-proxy) in the
+      # same values.yaml file.
+
       - name: Update alerting values.yaml
         run: |
           if [ -f "deploy/helm/alerting/values.yaml" ]; then
-            sed -i 's|tag: .*|tag: '"${{ inputs.version }}"'|' deploy/helm/alerting/values.yaml
+            sed -i '/repository:.*aiobs-metrics-alerting/{n;s|tag: .*|tag: '"${{ inputs.version }}"'|}' deploy/helm/alerting/values.yaml
             echo "Updated deploy/helm/alerting/values.yaml"
           fi
 
       - name: Update mcp-server values.yaml
         run: |
           if [ -f "deploy/helm/mcp-server/values.yaml" ]; then
-            sed -i 's|tag: .*|tag: '"${{ inputs.version }}"'|' deploy/helm/mcp-server/values.yaml
+            sed -i '/repository:.*aiobs-mcp-server/{n;s|tag: .*|tag: '"${{ inputs.version }}"'|}' deploy/helm/mcp-server/values.yaml
             echo "Updated deploy/helm/mcp-server/values.yaml"
           fi
 
       - name: Update openshift-console-plugin values.yaml
         run: |
           if [ -f "deploy/helm/openshift-console-plugin/values.yaml" ]; then
-            sed -i 's|tag: .*|tag: '"${{ inputs.version }}"'|' deploy/helm/openshift-console-plugin/values.yaml
+            sed -i '/repository:.*aiobs-console-plugin/{n;s|tag: .*|tag: '"${{ inputs.version }}"'|}' deploy/helm/openshift-console-plugin/values.yaml
             echo "Updated deploy/helm/openshift-console-plugin/values.yaml"
+          fi
+
+      - name: Update react-ui-app values.yaml
+        run: |
+          if [ -f "deploy/helm/react-ui-app/values.yaml" ]; then
+            sed -i '/repository:.*aiobs-react-ui/{n;s|tag: .*|tag: '"${{ inputs.version }}"'|}' deploy/helm/react-ui-app/values.yaml
+            echo "Updated deploy/helm/react-ui-app/values.yaml"
           fi
 
       - name: Update Makefile version

--- a/deploy/helm/react-ui-app/values.yaml
+++ b/deploy/helm/react-ui-app/values.yaml
@@ -39,7 +39,7 @@ oauth:
   enabled: true
   image:
     repository: "quay.io/openshift/origin-oauth-proxy"
-    tag: "4.14"
+    tag: 4.22.0
     pullPolicy: IfNotPresent
   port: 8443
   upstreamTimeout: "240s"  # Timeout for upstream requests (AI analysis can take time)


### PR DESCRIPTION
**This PR is targeted to `main` branch as the workflow needs to be fixed in that branch otherwise the values.yaml will get overwritten with every PR merge into the `dev` branch**. _Once this PR is merged into `main` branch, I'll create another PR to fix the `oauth.image.tag` for `dev` branch_

## Changes

  - The "Update Versions" workflow used a blanket `sed 's|tag: .*|tag: VERSION|'` that replaced every tag: line in each `values.yaml`
  - In `react-ui-app/values.yaml`, this overwrote `oauth.image.tag` with the app version, breaking the react-ui deployment
  - PR #246's upgrade to `origin-oauth-proxy:4.22.0` was undone within minutes by the next automated version bump
  - Each sed now anchors on the app's specific repository: line before substituting, so only the app image tag is updated
  - Restores `oauth.image.tag` to `4.22.0`

**_For now, I've manually patched `react-ui` deployment in our cluster by running the following command:_**
```
oc set image deployment/aiobs-react-ui oauth-proxy=quay.io/openshift/origin-oauth-proxy:4.22.0 -n ai-observability
```

## Checklist

- [ ] Verify on the cluster
- [ ] Update tests if applicable and run `make test`
- [ ] Add screenshots (if applicable)
- [ ] Update readme (if applicable)