### PR TITLE
feat: add connection testing for MaaS models with validation

### DIFF
--- a/openshift-plugin/src/core/components/AIModelSettings/services/secretManager.ts
+++ b/openshift-plugin/src/core/components/AIModelSettings/services/secretManager.ts
@@ -203,6 +203,59 @@ class AISecretManager {
   }
 
   /**
+   * Test MaaS model connection with per-model API key and endpoint
+   * MaaS models use individual API keys, unlike other providers
+   */
+  async testMaasConnection(modelId: string, apiKey: string, endpoint?: string): Promise<ConnectionTestResult> {
+    const startTime = Date.now();
+
+    if (!apiKey) {
+      return {
+        success: false,
+        error: 'API key is required for testing',
+      };
+    }
+
+    if (!endpoint) {
+      return {
+        success: false,
+        error: 'Endpoint is required for MaaS models',
+      };
+    }
+
+    try {
+      const result = await callMcpTool<{ success: boolean; details?: any }>('validate_api_key', {
+        provider: 'maas',
+        api_key: apiKey,
+        endpoint: endpoint,
+        model_id: modelId,
+      });
+
+      const details: ConnectionTestResult['details'] = {
+        responseTime: Date.now() - startTime,
+        ...(result.details || {}),
+      };
+
+      const success = !!result.success;
+
+      return {
+        success,
+        error: success ? undefined : 'Connection test failed - invalid API key or endpoint',
+        details,
+      };
+    } catch (error) {
+      console.error('[SecretManager] MaaS test error:', error);
+      return {
+        success: false,
+        error: error instanceof Error ? error.message : 'Connection test failed',
+        details: {
+          responseTime: Date.now() - startTime,
+        },
+      };
+    }
+  }
+
+  /**
    * Delete secret using MCP tool (production) or clear cached credential (dev mode)
    * Works in all deployment modes: console plugin, react-ui, and dev
    */

--- a/openshift-plugin/src/core/components/AIModelSettings/tabs/AddModelTab.tsx
+++ b/openshift-plugin/src/core/components/AIModelSettings/tabs/AddModelTab.tsx
@@ -28,11 +28,13 @@ import {
 import {
   PlusCircleIcon,
   SearchIcon,
+  SyncAltIcon,
 } from '@patternfly/react-icons';
 
 import { AIModelState, ModelFormData, Provider, ProviderModel } from '../types/models';
 import { getAllProviders, getProviderTemplate, formatModelName } from '../services/providerTemplates';
 import { modelService } from '../services/modelService';
+import { secretManager } from '../services/secretManager';
 import { isDevMode } from '../../../services/runtimeConfig';
 
 interface AddModelTabProps {
@@ -61,7 +63,9 @@ export const AddModelTab: React.FC<AddModelTabProps> = ({
     description: '',
   });
   const [saving, setSaving] = React.useState(false);
+  const [testing, setTesting] = React.useState(false);
   const [error, setError] = React.useState<string | null>(null);
+  const [testSuccess, setTestSuccess] = React.useState<string | null>(null);
   const [availableModels, setAvailableModels] = React.useState<ProviderModel[]>([]);
   const [loadingModels, setLoadingModels] = React.useState(false);
   const [customModelId, setCustomModelId] = React.useState('');
@@ -117,9 +121,60 @@ export const AddModelTab: React.FC<AddModelTabProps> = ({
     setIsConfiguredModel(false);
     setMode('add');
     setError(null);
+    setTestSuccess(null);
 
     // Fetch available models for the selected provider
     fetchAvailableModels(provider);
+  };
+
+  const handleTestConnection = async () => {
+    setError(null);
+    setTestSuccess(null);
+
+    // Get the actual model ID
+    const actualModelId = customModelId.trim() || formData.modelId.trim();
+
+    if (!actualModelId) {
+      setError('Please select or enter a model ID');
+      return;
+    }
+
+    if (!formData.apiKey?.trim()) {
+      setError('API key is required to test connection');
+      return;
+    }
+
+    if (!formData.endpoint?.trim()) {
+      setError('Endpoint is required to test connection');
+      return;
+    }
+
+    setTesting(true);
+
+    try {
+      const result = await secretManager.testMaasConnection(
+        actualModelId,
+        formData.apiKey,
+        formData.endpoint
+      );
+
+      if (result.success) {
+        const responseTime = result.details?.responseTime || 'N/A';
+        const statusCode = result.details?.status;
+        const statusMsg = statusCode ? ` (HTTP ${statusCode})` : '';
+        setTestSuccess(`✓ Connection successful! Response time: ${responseTime}ms${statusMsg}`);
+      } else {
+        const errorMsg = result.error || 'Connection test failed - please check your API key and endpoint';
+        const statusCode = result.details?.status;
+        const statusMsg = statusCode ? ` (HTTP ${statusCode})` : '';
+        setError(`${errorMsg}${statusMsg}`);
+      }
+    } catch (err) {
+      console.error('[AddModelTab] Test error:', err);
+      setError(err instanceof Error ? err.message : 'Connection test failed');
+    } finally {
+      setTesting(false);
+    }
   };
 
   // Fetch models on initial load
@@ -164,8 +219,29 @@ export const AddModelTab: React.FC<AddModelTabProps> = ({
 
     setSaving(true);
     setError(null);
+    setTestSuccess(null);
 
     try {
+      // For MaaS models, validate the API key before saving
+      if (formData.provider === 'maas' && formData.apiKey && formData.endpoint) {
+        const validationResult = await secretManager.testMaasConnection(
+          actualModelId,
+          formData.apiKey,
+          formData.endpoint
+        );
+
+        if (!validationResult.success) {
+          const statusCode = validationResult.details?.status;
+          const statusMsg = statusCode ? ` (HTTP ${statusCode})` : '';
+          setError(
+            `Cannot ${mode === 'update' ? 'update' : 'add'} model: Invalid API key or endpoint${statusMsg}. ` +
+            'Please verify your credentials and try again.'
+          );
+          setSaving(false);
+          return;
+        }
+      }
+
       if (mode === 'update' && formData.provider === 'maas') {
         // Update existing MAAS model API key
         await modelService.updateMaasModelApiKey({
@@ -268,6 +344,16 @@ export const AddModelTab: React.FC<AddModelTabProps> = ({
                     </div>
                   )}
                 </div>
+              </Alert>
+            )}
+            {testSuccess && (
+              <Alert
+                variant={AlertVariant.success}
+                title="Connection Test Successful"
+                isInline
+                style={{ marginBottom: '20px' }}
+              >
+                {testSuccess}
               </Alert>
             )}
 
@@ -458,6 +544,7 @@ export const AddModelTab: React.FC<AddModelTabProps> = ({
                     onClick={handleSubmit}
                     isDisabled={
                       saving ||
+                      testing ||
                       (!formData.modelId.trim() && !customModelId.trim()) ||
                       (formData.provider === 'maas' && !formData.apiKey?.trim())
                     }
@@ -467,6 +554,25 @@ export const AddModelTab: React.FC<AddModelTabProps> = ({
                     {mode === 'update' ? 'Update API Key' : 'Add Model'}
                   </Button>
                 </FlexItem>
+                {formData.provider === 'maas' && (
+                  <FlexItem>
+                    <Button
+                      variant="secondary"
+                      onClick={handleTestConnection}
+                      isDisabled={
+                        testing ||
+                        saving ||
+                        (!formData.modelId.trim() && !customModelId.trim()) ||
+                        !formData.apiKey?.trim() ||
+                        !formData.endpoint?.trim()
+                      }
+                      isLoading={testing}
+                    >
+                      <SyncAltIcon style={{ marginRight: '8px' }} />
+                      {testing ? 'Testing...' : 'Test Connection'}
+                    </Button>
+                  </FlexItem>
+                )}
                 <FlexItem>
                   <Button
                     variant="link"
@@ -482,6 +588,7 @@ export const AddModelTab: React.FC<AddModelTabProps> = ({
                       setIsConfiguredModel(false);
                       setMode('add');
                       setError(null);
+                      setTestSuccess(null);
                       fetchAvailableModels('maas');
                     }}
                   >

--- a/openshift-plugin/src/core/components/AIModelSettings/types/models.ts
+++ b/openshift-plugin/src/core/components/AIModelSettings/types/models.ts
@@ -102,6 +102,7 @@ export interface ConnectionTestResult {
     responseTime?: number;
     modelCount?: number;
     supportedFeatures?: string[];
+    status?: number;  // HTTP status code
   };
 }
 

--- a/src/mcp_server/tools/credentials_tools.py
+++ b/src/mcp_server/tools/credentials_tools.py
@@ -27,10 +27,16 @@ def _provider_defaults(provider: str) -> Dict[str, str]:
     return {"endpoint": ""}
 
 
-def validate_api_key(provider: str, api_key: str, endpoint: Optional[str] = None) -> List[Dict[str, Any]]:
+def validate_api_key(provider: str, api_key: str, endpoint: Optional[str] = None, model_id: Optional[str] = None) -> List[Dict[str, Any]]:
     """
     Validate an API key for a given provider by making a minimal request server-side.
     Returns structured MCP content with { success, details }.
+
+    Args:
+        provider: Provider name (openai, anthropic, google, meta, maas)
+        api_key: API key to validate
+        endpoint: Optional custom endpoint URL
+        model_id: Optional model ID (required for MaaS)
     """
     try:
         if not provider or not api_key:
@@ -75,6 +81,52 @@ def validate_api_key(provider: str, api_key: str, endpoint: Optional[str] = None
             r = requests.get(ep, headers={"Authorization": f"Bearer {api_key}"}, timeout=timeout)
             ok = r.status_code == 200
             details["status"] = r.status_code
+        elif provider_lower == "maas":
+            # MaaS uses per-model API keys with custom endpoints
+            # Test by making a minimal chat completion request with the actual model
+            if not model_id:
+                raise MCPException(
+                    message="model_id is required for MaaS validation",
+                    error_code=MCPErrorCode.INVALID_INPUT,
+                )
+
+            test_url = ep.rstrip('/')
+            # Ensure we're testing the /chat/completions endpoint
+            if not test_url.endswith('/chat/completions'):
+                if test_url.endswith('/v1'):
+                    test_url = f"{test_url}/chat/completions"
+                else:
+                    test_url = f"{test_url}/v1/chat/completions"
+
+            # Clean model ID (remove maas/ prefix if present)
+            clean_model_id = model_id.replace("maas/", "").strip()
+            logger.info(f"Testing MaaS connection to: {test_url} with model: {clean_model_id}")
+
+            # Make a minimal test request with the actual model ID
+            # A valid API key will return 200 (success) or 400 (bad request but authenticated)
+            # An invalid API key will return 401 (unauthorized) or 403 (forbidden)
+            test_payload = {
+                "model": clean_model_id,
+                "messages": [{"role": "user", "content": "test"}],
+                "max_tokens": 1
+            }
+            r = requests.post(
+                test_url,
+                headers={
+                    "Authorization": f"Bearer {api_key}",
+                    "Content-Type": "application/json"
+                },
+                json=test_payload,
+                timeout=timeout
+            )
+            # 200/201 = valid key and successful request
+            # 400 = bad request but valid auth (key is valid)
+            # 401 = unauthorized (invalid key)
+            # 403 = forbidden (invalid key)
+            # 422 = validation error but valid auth (key is valid)
+            ok = r.status_code not in (401, 403)
+            details["status"] = r.status_code
+            logger.info(f"MaaS validation result - Status: {r.status_code}, Valid: {ok}")
         else:
             raise MCPException(
                 message=f"Unsupported provider: {provider}",


### PR DESCRIPTION
## Changes

Adds connection testing capability for MaaS (Model as a Service) models before adding or updating them:

- **Test Connection button**: Users can manually test MaaS API credentials before saving
- **Automatic validation**: Prevents saving models with invalid API keys or endpoints
- **Clear feedback**: Shows response time and HTTP status codes in success/error messages

## Testing
Deployed and tested in our dev cluster in `jianrong` namespace.

- [x] Test valid MaaS credentials → Shows success message with response time
- [x] Test invalid API key → Shows error message with HTTP 401
- [x] Test invalid endpoint → Shows connection error
- [x] Add model with valid credentials → Successfully saves
- [x] Add model with invalid credentials → Blocks save with error message
- [x] Update existing model API key → Validates before updating

<img width="747" height="660" alt="Screenshot 2026-03-19 at 9 39 50 AM" src="https://github.com/user-attachments/assets/c5ac46f0-0dce-4de0-80b0-36e20e27b54a" />
<img width="549" height="639" alt="Screenshot 2026-03-19 at 9 41 18 AM" src="https://github.com/user-attachments/assets/851ebc0d-8920-47d2-8a07-3141c38ad52e" />

## Checklist

- [x] Verify on the cluster
- [ ] Update tests if applicable and run `make test`
- [x] Add screenshots (if applicable)
- [ ] Update readme (if applicable)