### PR TITLE
fix: ensure Clear Cache button properly clears all dev mode data and updates UI

### DIFF
--- a/openshift-plugin/src/core/components/AIModelSettings/components/DevModeBanner.tsx
+++ b/openshift-plugin/src/core/components/AIModelSettings/components/DevModeBanner.tsx
@@ -2,23 +2,29 @@ import * as React from 'react';
 import { Alert, AlertVariant, Button } from '@patternfly/react-core';
 import { listDevProviders, clearDevCredentials, clearDevModels, getDevModels } from '../../../services/devCredentials';
 import { isDevMode } from '../../../services/runtimeConfig';
+import { clearSessionConfig, getSessionConfig } from '../../../services/mcpClient';
 
 export const DevModeBanner: React.FC = () => {
   const [cachedProviders, setCachedProviders] = React.useState<string[]>([]);
   const [modelCount, setModelCount] = React.useState<number>(0);
+  const [hasSelectedModel, setHasSelectedModel] = React.useState<boolean>(false);
   const devMode = isDevMode();
 
   React.useEffect(() => {
     if (devMode) {
-      // Refresh cached providers and models list every 2 seconds
+      // Refresh cached providers, models list, and selected model every 2 seconds
       const interval = setInterval(() => {
         setCachedProviders(listDevProviders());
         setModelCount(Object.keys(getDevModels()).length);
+        const config = getSessionConfig();
+        setHasSelectedModel(!!config.ai_model);
       }, 2000);
 
       // Initial load
       setCachedProviders(listDevProviders());
       setModelCount(Object.keys(getDevModels()).length);
+      const config = getSessionConfig();
+      setHasSelectedModel(!!config.ai_model);
 
       return () => clearInterval(interval);
     }
@@ -27,8 +33,13 @@ export const DevModeBanner: React.FC = () => {
   const handleClearCache = () => {
     clearDevCredentials();
     clearDevModels();
+    clearSessionConfig();
     setCachedProviders([]);
     setModelCount(0);
+    setHasSelectedModel(false);
+
+    // Notify parent component to reload models
+    window.dispatchEvent(new CustomEvent('dev-cache-cleared'));
   };
 
   if (!devMode) {
@@ -42,7 +53,7 @@ export const DevModeBanner: React.FC = () => {
       title="Development Mode Active"
       style={{ marginBottom: '20px' }}
       actionClose={
-        (cachedProviders.length > 0 || modelCount > 0) ? (
+        (cachedProviders.length > 0 || modelCount > 0 || hasSelectedModel) ? (
           <Button variant="link" onClick={handleClearCache}>
             Clear Cache
           </Button>
@@ -59,7 +70,7 @@ export const DevModeBanner: React.FC = () => {
       <p>
         <em>Note: All data is stored in sessionStorage and will be cleared when you close this browser tab.</em>
       </p>
-      {(cachedProviders.length > 0 || modelCount > 0) && (
+      {(cachedProviders.length > 0 || modelCount > 0 || hasSelectedModel) && (
         <div style={{ marginTop: '10px' }}>
           {cachedProviders.length > 0 && (
             <p>
@@ -69,6 +80,11 @@ export const DevModeBanner: React.FC = () => {
           {modelCount > 0 && (
             <p>
               <strong>Cached models:</strong> {modelCount} model{modelCount !== 1 ? 's' : ''}
+            </p>
+          )}
+          {hasSelectedModel && (
+            <p>
+              <strong>Selected model for analysis:</strong> {getSessionConfig().ai_model}
             </p>
           )}
         </div>

--- a/openshift-plugin/src/core/components/AIModelSettings/components/DevModeBanner.tsx
+++ b/openshift-plugin/src/core/components/AIModelSettings/components/DevModeBanner.tsx
@@ -3,6 +3,7 @@ import { Alert, AlertVariant, Button } from '@patternfly/react-core';
 import { listDevProviders, clearDevCredentials, clearDevModels, getDevModels } from '../../../services/devCredentials';
 import { isDevMode } from '../../../services/runtimeConfig';
 import { clearSessionConfig, getSessionConfig } from '../../../services/mcpClient';
+import { dispatchDevCacheClearedEvent } from '../../../constants';
 
 // Poll every 2 seconds to keep UI in sync with cached data in dev mode
 const DEV_CACHE_POLL_INTERVAL_MS = 2000;
@@ -45,8 +46,8 @@ export const DevModeBanner: React.FC = () => {
     setHasSelectedModel(false);
     setSelectedModelName('');
 
-    // Notify parent component to reload models
-    window.dispatchEvent(new CustomEvent('dev-cache-cleared'));
+    // Notify parent components to reload data
+    dispatchDevCacheClearedEvent();
   };
 
   if (!devMode) {

--- a/openshift-plugin/src/core/components/AIModelSettings/components/DevModeBanner.tsx
+++ b/openshift-plugin/src/core/components/AIModelSettings/components/DevModeBanner.tsx
@@ -4,27 +4,33 @@ import { listDevProviders, clearDevCredentials, clearDevModels, getDevModels } f
 import { isDevMode } from '../../../services/runtimeConfig';
 import { clearSessionConfig, getSessionConfig } from '../../../services/mcpClient';
 
+// Poll every 2 seconds to keep UI in sync with cached data in dev mode
+const DEV_CACHE_POLL_INTERVAL_MS = 2000;
+
 export const DevModeBanner: React.FC = () => {
   const [cachedProviders, setCachedProviders] = React.useState<string[]>([]);
   const [modelCount, setModelCount] = React.useState<number>(0);
   const [hasSelectedModel, setHasSelectedModel] = React.useState<boolean>(false);
+  const [selectedModelName, setSelectedModelName] = React.useState<string>('');
   const devMode = isDevMode();
 
   React.useEffect(() => {
     if (devMode) {
-      // Refresh cached providers, models list, and selected model every 2 seconds
+      // Refresh cached providers, models list, and selected model
       const interval = setInterval(() => {
         setCachedProviders(listDevProviders());
         setModelCount(Object.keys(getDevModels()).length);
         const config = getSessionConfig();
         setHasSelectedModel(!!config.ai_model);
-      }, 2000);
+        setSelectedModelName(config.ai_model || '');
+      }, DEV_CACHE_POLL_INTERVAL_MS);
 
       // Initial load
       setCachedProviders(listDevProviders());
       setModelCount(Object.keys(getDevModels()).length);
       const config = getSessionConfig();
       setHasSelectedModel(!!config.ai_model);
+      setSelectedModelName(config.ai_model || '');
 
       return () => clearInterval(interval);
     }
@@ -37,6 +43,7 @@ export const DevModeBanner: React.FC = () => {
     setCachedProviders([]);
     setModelCount(0);
     setHasSelectedModel(false);
+    setSelectedModelName('');
 
     // Notify parent component to reload models
     window.dispatchEvent(new CustomEvent('dev-cache-cleared'));
@@ -84,7 +91,7 @@ export const DevModeBanner: React.FC = () => {
           )}
           {hasSelectedModel && (
             <p>
-              <strong>Selected model for analysis:</strong> {getSessionConfig().ai_model}
+              <strong>Selected model for analysis:</strong> {selectedModelName}
             </p>
           )}
         </div>

--- a/openshift-plugin/src/core/components/AIModelSettings/index.tsx
+++ b/openshift-plugin/src/core/components/AIModelSettings/index.tsx
@@ -54,6 +54,19 @@ export const AIModelSettings: React.FC<AIModelSettingsProps> = ({
     }
   }, [isOpen]);
 
+  // Listen for dev cache clear events
+  React.useEffect(() => {
+    const handleCacheCleared = () => {
+      console.log('[AIModelSettings] Dev cache cleared, reloading models...');
+      loadInitialData();
+    };
+
+    window.addEventListener('dev-cache-cleared', handleCacheCleared);
+    return () => {
+      window.removeEventListener('dev-cache-cleared', handleCacheCleared);
+    };
+  }, []);
+
   const loadInitialData = async () => {
     setState(prev => ({
       ...prev,
@@ -71,18 +84,29 @@ export const AIModelSettings: React.FC<AIModelSettingsProps> = ({
       if (modelsResult.status === 'fulfilled') {
         const { internal, external, custom } = modelsResult.value;
         setState(prev => {
+          // Always refresh selectedModel from session config
+          const currentModel = modelService.getCurrentModel();
+
           const next = {
             ...prev,
             internalModels: internal,
             externalModels: external,
             customModels: custom,
+            selectedModel: currentModel,
             loading: { ...prev.loading, models: false },
           };
+
           // If nothing is selectable, clear selected model in session
           if (!hasSelectableModels(next)) {
             modelService.setCurrentModel('');
             next.selectedModel = null;
           }
+          // If selected model is not in the available models list, clear it
+          else if (currentModel && !isModelSelectable(next, currentModel)) {
+            modelService.setCurrentModel('');
+            next.selectedModel = null;
+          }
+
           return next;
         });
       } else {

--- a/openshift-plugin/src/core/components/AIModelSettings/index.tsx
+++ b/openshift-plugin/src/core/components/AIModelSettings/index.tsx
@@ -32,6 +32,7 @@ import { ChatSettingsTab } from './tabs/ChatSettingsTab';
 import { MetricsSettingsTab } from './tabs/MetricsSettingsTab';
 import { isDevMode } from '../../services/runtimeConfig';
 import { useChatSettings } from '../../hooks/useChatSettings';
+import { DEV_CACHE_CLEARED_EVENT } from '../../constants';
 
 interface AIModelSettingsProps {
   isOpen: boolean;
@@ -47,27 +48,73 @@ export const AIModelSettings: React.FC<AIModelSettingsProps> = ({
   const [state, setState] = React.useState<AIModelState>(modelService.getInitialState());
   const { settings: chatSettings, updateSettings: updateChatSettings, resetSettings: resetChatSettings } = useChatSettings();
 
-  // Load initial data when modal opens
-  React.useEffect(() => {
-    if (isOpen) {
-      loadInitialData();
-    }
-  }, [isOpen]);
-
-  // Listen for dev cache clear events
-  React.useEffect(() => {
-    const handleCacheCleared = () => {
-      console.log('[AIModelSettings] Dev cache cleared, reloading models...');
-      loadInitialData();
-    };
-
-    window.addEventListener('dev-cache-cleared', handleCacheCleared);
-    return () => {
-      window.removeEventListener('dev-cache-cleared', handleCacheCleared);
-    };
+  const hasSelectableModels = React.useCallback((s: AIModelState): boolean => {
+    const internal = s.internalModels.length > 0;
+    const external = s.externalModels.some(m => m.provider === 'maas' || s.providers[m.provider]?.status === 'configured');
+    const custom = s.customModels.some(m => !m.requiresApiKey || m.provider === 'maas' || s.providers[m.provider]?.status === 'configured');
+    return internal || external || custom;
   }, []);
 
-  const loadInitialData = async () => {
+  const isModelSelectable = React.useCallback((s: AIModelState, modelName: string | null): boolean => {
+    if (!modelName) return false;
+    const all = [...s.internalModels, ...s.externalModels, ...s.customModels];
+    const m = all.find(mm => mm.name === modelName);
+    if (!m) return false;
+    if (!m.requiresApiKey) return true;
+    // MAAS models have per-model API keys configured when added
+    if (m.provider === 'maas') return true;
+    return s.providers[m.provider]?.status === 'configured';
+  }, []);
+
+  const loadProviderStatus = React.useCallback(async () => {
+    try {
+      // Get the initial state for providers (don't rely on current state)
+      const initialProviders = modelService.getInitialState().providers;
+      const providers = { ...initialProviders };
+
+      // Check each external provider for existing secrets
+      for (const provider of ['openai', 'anthropic', 'google', 'meta', 'other'] as const) {
+        const secretStatus = await secretManager.checkProviderSecret(provider);
+
+        // Determine storage type based on dev mode
+        let storageType: 'secret' | 'cache' | 'none' = 'none';
+        if (secretStatus.exists) {
+          storageType = isDevMode() ? 'cache' : 'secret';
+        }
+
+        providers[provider] = {
+          provider,
+          status: secretStatus.exists ? 'configured' : 'missing',
+          storage: storageType,
+          secretName: secretStatus.secretName,
+          lastUpdated: secretStatus.lastUpdated,
+          isValid: secretStatus.isValid,
+        };
+      }
+
+      setState(prev => {
+        const next = {
+          ...prev,
+          providers,
+          loading: { ...prev.loading, secrets: false },
+        };
+        // If nothing is selectable with updated providers, clear current model
+        if (!hasSelectableModels(next)) {
+          modelService.setCurrentModel('');
+          next.selectedModel = null;
+        }
+        return next;
+      });
+    } catch (error) {
+      console.error('Error loading provider status:', error);
+      setState(prev => ({
+        ...prev,
+        loading: { ...prev.loading, secrets: false },
+      }));
+    }
+  }, [hasSelectableModels]);
+
+  const loadInitialData = React.useCallback(async () => {
     setState(prev => ({
       ...prev,
       loading: { ...prev.loading, models: true, secrets: true },
@@ -119,73 +166,26 @@ export const AIModelSettings: React.FC<AIModelSettingsProps> = ({
         loading: { models: false, secrets: false, testing: false, saving: false },
       }));
     }
-  };
+  }, [hasSelectableModels, isModelSelectable, loadProviderStatus]);
 
-  const loadProviderStatus = async () => {
-    try {
-      // Get the initial state for providers (don't rely on current state)
-      const initialProviders = modelService.getInitialState().providers;
-      const providers = { ...initialProviders };
-      
-      // Check each external provider for existing secrets
-      for (const provider of ['openai', 'anthropic', 'google', 'meta', 'other'] as const) {
-        const secretStatus = await secretManager.checkProviderSecret(provider);
-
-        // Determine storage type based on dev mode
-        let storageType: 'secret' | 'cache' | 'none' = 'none';
-        if (secretStatus.exists) {
-          storageType = isDevMode() ? 'cache' : 'secret';
-        }
-
-        providers[provider] = {
-          provider,
-          status: secretStatus.exists ? 'configured' : 'missing',
-          storage: storageType,
-          secretName: secretStatus.secretName,
-          lastUpdated: secretStatus.lastUpdated,
-          isValid: secretStatus.isValid,
-        };
-      }
-
-      setState(prev => {
-        const next = {
-          ...prev,
-          providers,
-          loading: { ...prev.loading, secrets: false },
-        };
-        // If nothing is selectable with updated providers, clear current model
-        if (!hasSelectableModels(next)) {
-          modelService.setCurrentModel('');
-          next.selectedModel = null;
-        }
-        return next;
-      });
-    } catch (error) {
-      console.error('Error loading provider status:', error);
-      setState(prev => ({
-        ...prev,
-        loading: { ...prev.loading, secrets: false },
-      }));
+  // Load initial data when modal opens
+  React.useEffect(() => {
+    if (isOpen) {
+      loadInitialData();
     }
-  };
+  }, [isOpen, loadInitialData]);
 
-  const hasSelectableModels = (s: AIModelState): boolean => {
-    const internal = s.internalModels.length > 0;
-    const external = s.externalModels.some(m => m.provider === 'maas' || s.providers[m.provider]?.status === 'configured');
-    const custom = s.customModels.some(m => !m.requiresApiKey || m.provider === 'maas' || s.providers[m.provider]?.status === 'configured');
-    return internal || external || custom;
-  };
+  // Listen for dev cache clear events
+  React.useEffect(() => {
+    const handleCacheCleared = () => {
+      loadInitialData();
+    };
 
-  const isModelSelectable = (s: AIModelState, modelName: string | null): boolean => {
-    if (!modelName) return false;
-    const all = [...s.internalModels, ...s.externalModels, ...s.customModels];
-    const m = all.find(mm => mm.name === modelName);
-    if (!m) return false;
-    if (!m.requiresApiKey) return true;
-    // MAAS models have per-model API keys configured when added
-    if (m.provider === 'maas') return true;
-    return s.providers[m.provider]?.status === 'configured';
-  };
+    window.addEventListener(DEV_CACHE_CLEARED_EVENT, handleCacheCleared);
+    return () => {
+      window.removeEventListener(DEV_CACHE_CLEARED_EVENT, handleCacheCleared);
+    };
+  }, [loadInitialData]);
 
   const handleTabSelect = (_event: React.MouseEvent<HTMLElement, MouseEvent>, tabIndex: string | number) => {
     const tabName = tabIndex as AIModelState['activeTab'];

--- a/openshift-plugin/src/core/constants.ts
+++ b/openshift-plugin/src/core/constants.ts
@@ -1,0 +1,11 @@
+/**
+ * Event names for cross-component communication
+ */
+export const DEV_CACHE_CLEARED_EVENT = 'dev-cache-cleared';
+
+/**
+ * Helper to dispatch dev cache cleared event
+ */
+export function dispatchDevCacheClearedEvent(): void {
+  window.dispatchEvent(new CustomEvent(DEV_CACHE_CLEARED_EVENT));
+}

--- a/openshift-plugin/src/core/pages/AIObservabilityPage.tsx
+++ b/openshift-plugin/src/core/pages/AIObservabilityPage.tsx
@@ -32,6 +32,7 @@ import { ModelInsightsSection, QuickActionsSection, StatusSummarySection } from 
 import { getSessionConfig, healthCheck, listModels, listNamespaces } from '../services/mcpClient';
 import type { ModelInfo, NamespaceInfo } from '../services/mcpClient';
 import { initializeRuntimeConfig } from '../services/runtimeConfig';
+import { DEV_CACHE_CLEARED_EVENT } from '../constants';
 
 // Overview Dashboard Component
 const OverviewDashboard: React.FC = () => {
@@ -136,19 +137,18 @@ const AIObservabilityPage: React.FC<AIObservabilityPageProps> = ({
       }
     };
     const handleCacheCleared = () => {
-      console.log('[AIObservabilityPage] Dev cache cleared, updating configured model...');
       const updatedConfig = getSessionConfig();
       setConfiguredModel(updatedConfig.ai_model || '');
     };
 
     window.addEventListener('open-settings', handleOpenSettings);
     window.addEventListener('quick-action-navigate', handleQuickActionNavigate);
-    window.addEventListener('dev-cache-cleared', handleCacheCleared);
+    window.addEventListener(DEV_CACHE_CLEARED_EVENT, handleCacheCleared);
 
     return () => {
       window.removeEventListener('open-settings', handleOpenSettings);
       window.removeEventListener('quick-action-navigate', handleQuickActionNavigate);
-      window.removeEventListener('dev-cache-cleared', handleCacheCleared);
+      window.removeEventListener(DEV_CACHE_CLEARED_EVENT, handleCacheCleared);
     };
   }, [setActiveTabKey]);
 

--- a/openshift-plugin/src/core/pages/AIObservabilityPage.tsx
+++ b/openshift-plugin/src/core/pages/AIObservabilityPage.tsx
@@ -135,13 +135,20 @@ const AIObservabilityPage: React.FC<AIObservabilityPageProps> = ({
         setActiveTabKey(detail.tabIndex);
       }
     };
+    const handleCacheCleared = () => {
+      console.log('[AIObservabilityPage] Dev cache cleared, updating configured model...');
+      const updatedConfig = getSessionConfig();
+      setConfiguredModel(updatedConfig.ai_model || '');
+    };
 
     window.addEventListener('open-settings', handleOpenSettings);
     window.addEventListener('quick-action-navigate', handleQuickActionNavigate);
+    window.addEventListener('dev-cache-cleared', handleCacheCleared);
 
     return () => {
       window.removeEventListener('open-settings', handleOpenSettings);
       window.removeEventListener('quick-action-navigate', handleQuickActionNavigate);
+      window.removeEventListener('dev-cache-cleared', handleCacheCleared);
     };
   }, [setActiveTabKey]);
 


### PR DESCRIPTION
## Summary
- Fixed Clear Cache button in dev mode to clear session config (selected model) in addition to API keys and models
- Added event-driven UI refresh when cache is cleared to keep all components in sync
- Enhanced dev mode banner to show Clear Cache button whenever there's any cached data
- Display currently selected model in the dev mode banner for better visibility

## Changes
- **DevModeBanner.tsx**: Added session config clearing and event dispatch, plus selected model tracking and display
- **AIModelSettings/index.tsx**: Added event listener to reload models when cache is cleared, with validation to clear stale model selections
- **AIObservabilityPage.tsx**: Added event listener to update configured model display when cache is cleared

## Test plan
- [x] Add a MaaS model in dev mode
- [x] Select the model from Available Models
- [x] Click Clear Cache button
- [x] Verify model list is updated immediately
- [x] Verify Settings button label updates (removes model name)
- [x] Verify no stale model warnings appear
- [x] Verify Clear Cache button appears when only a model is selected (no API keys/models added)

## Checklist

- [x] Verify on the cluster
- [ ] Update tests if applicable and run `make test`
- [ ] Add screenshots (if applicable)
- [ ] Update readme (if applicable)