### PR TITLE
fix: invoke shell scripts via bash to avoid permission denied errors

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -112,7 +112,7 @@ LOKI_NAMESPACE ?= openshift-logging
 # LLM URL processing constants
 DEFAULT_LLM_PORT_AND_PATH := :8080/v1
 
-OPERATOR_MANAGER_SCRIPT := scripts/operator-manager.sh
+OPERATOR_MANAGER_SCRIPT := bash scripts/operator-manager.sh
 
 # Helm argument templates
 
@@ -1070,7 +1070,7 @@ upgrade-observability:
 
 .PHONY: check-observability-drift
 check-observability-drift:
-	@scripts/check-observability-drift.sh $(OBSERVABILITY_NAMESPACE) $(LOKI_NAMESPACE)
+	@bash scripts/check-observability-drift.sh $(OBSERVABILITY_NAMESPACE) $(LOKI_NAMESPACE)
 
 
 # ---- Alert Example (Python) ----


### PR DESCRIPTION
## Summary
- Prefixes all shell script invocations in the Makefile with `bash` so they no longer depend on the execute permission bit
- Fixes `make: execvp: scripts/operator-manager.sh: Permission denied` when the repo is downloaded as a ZIP archive or cloned on filesystems that strip Unix file permissions

## Problem
Scripts invoked directly (`./scripts/foo.sh` or `scripts/foo.sh`) require the execute bit (`chmod +x`). This bit is **not preserved** when:
- The repo is downloaded as a ZIP from GitHub
- The repo is cloned on Windows/WSL with restrictive `umask` or `core.fileMode=false`
- Certain container or CI environments strip permissions

## Changes
- `OPERATOR_MANAGER_SCRIPT` variable: `scripts/operator-manager.sh` → `bash scripts/operator-manager.sh` (affects all 15 operator install/uninstall/check call sites)
- `check-observability-drift` target: `@scripts/check-observability-drift.sh` → `@bash scripts/check-observability-drift.sh`

## Test plan
- [ ] Run `make install-operators` on a fresh clone (or ZIP download) and verify no permission denied errors
- [ ] Run `make check-observability-drift` and verify it executes correctly
- [ ] Verify existing `make install` workflow still works end-to-end