### PR TITLE
fix: pin OpenTelemetry Python auto-instrumentation version and auto-enable tracing for alert-example

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -922,7 +922,8 @@ setup-tracing: namespace
 		echo "  → Instrumentation already exists in namespace $(NAMESPACE), skipping..."; \
 	else \
 		echo "  → Applying instrumentation configuration to namespace $(NAMESPACE)"; \
-		cd deploy/helm && oc apply -f $(INSTRUMENTATION_PATH) -n $(NAMESPACE); \
+		export INSTRUMENTATION_PYTHON_IMAGE=$$(yq eval '.instrumentation.python.image' deploy/helm/observability/otel-collector/values.yaml); \
+		envsubst < deploy/helm/$(INSTRUMENTATION_PATH) | oc apply -f - -n $(NAMESPACE); \
 	fi
 	@oc annotate namespace $(NAMESPACE) instrumentation.opentelemetry.io/inject-python="true" --overwrite
 
@@ -1085,7 +1086,7 @@ push-alert-example:
 	$(BUILD_TOOL) push $(ALERT_EXAMPLE_IMAGE)
 
 .PHONY: install-alert-example
-install-alert-example: namespace
+install-alert-example: namespace setup-tracing
 	@echo "→ Installing/Upgrading alert-example helm chart (deploys alert-example and trace-example)"
 	@helm upgrade --install alert-example $(ALERT_EXAMPLE_CHART_PATH) -n $(NAMESPACE) \
 		--create-namespace \

--- a/deploy/helm/observability/otel-collector/scripts/instrumentation.yaml
+++ b/deploy/helm/observability/otel-collector/scripts/instrumentation.yaml
@@ -12,7 +12,7 @@ spec:
     - baggage
     - b3
   python:
-    image: "ghcr.io/open-telemetry/opentelemetry-operator/autoinstrumentation-python:latest"
+    image: "${INSTRUMENTATION_PYTHON_IMAGE}"
     # The operator automatically injects environment variables,
     # but you can add more here if needed.
     env:

--- a/deploy/helm/observability/otel-collector/values.yaml
+++ b/deploy/helm/observability/otel-collector/values.yaml
@@ -2,6 +2,13 @@
 global:
   namespace: observability-hub
 
+# Auto-instrumentation configuration
+instrumentation:
+  python:
+    # Version of the OpenTelemetry Python auto-instrumentation image
+    # https://github.com/open-telemetry/opentelemetry-operator/releases
+    image: "ghcr.io/open-telemetry/opentelemetry-operator/autoinstrumentation-python:0.60b0"
+
 # Common configuration for all collectors
 common:
   nameOverride: ""


### PR DESCRIPTION
## Summary

This PR addresses two issues with OpenTelemetry tracing setup:

1. **Pin auto-instrumentation image to specific version (0.60b0)**. Current  image ghcr.io/open-telemetry/opentelemetry-operator/autoinstrumentation-python:latest could break when new versions are released.

2. **Auto-enable tracing when deploying alert-example**

## Root Cause Analysis

The issue was discovered when `my-app-example` pod showed this error:
```
Failed to export batch code: 404, reason: 404 page not found
```

Investigation revealed:
- The failing cluster was **missing the `Instrumentation` resource** in the app's namespace
- Auto-instrumentation was using `:latest` tag, which could break when new versions are released
- The working cluster had the `Instrumentation` resource properly configured

## Test Plan
Deployed and tested successfully in team devt cluster under `jianrong` namespace.
- [x] Verified `setup-tracing` correctly substitutes version from values.yaml
- [x] Confirmed `install-alert-example` automatically sets up tracing
- [x] Tested in cluster where Instrumentation was missing - now works correctly

<img width="1359" height="657" alt="Screenshot 2026-03-31 at 7 51 33 PM" src="https://github.com/user-attachments/assets/0ca0c04a-80e8-4b6e-bbf8-98682a380aa0" />

## Checklist

- [x] Verify on the cluster
- [ ] Update tests if applicable and run `make test`
- [X] Add screenshots (if applicable)
- [ ] Update readme (if applicable)