### PR TITLE
fix: add pull-rebase and retry logic to prevent push failures

### DIFF
--- a/.github/workflows/build-operator-images.yml
+++ b/.github/workflows/build-operator-images.yml
@@ -111,7 +111,31 @@ jobs:
           - Update catalog-source.yaml catalog image reference
           EOF
           )"
-            git push origin ${GITHUB_REF#refs/heads/}
+
+            # Pull latest changes before pushing (handles race conditions)
+            echo "Pulling latest changes..."
+            git pull --rebase origin ${GITHUB_REF#refs/heads/}
+
+            # Push with retry logic
+            echo "Pushing changes..."
+            max_retries=3
+            retry_count=0
+            while [ $retry_count -lt $max_retries ]; do
+              if git push origin ${GITHUB_REF#refs/heads/}; then
+                echo "✅ Successfully pushed changes"
+                break
+              else
+                retry_count=$((retry_count + 1))
+                if [ $retry_count -lt $max_retries ]; then
+                  echo "Push failed, retrying ($retry_count/$max_retries)..."
+                  git pull --rebase origin ${GITHUB_REF#refs/heads/}
+                  sleep 2
+                else
+                  echo "❌ Failed to push after $max_retries attempts"
+                  exit 1
+                fi
+              fi
+            done
           fi
 
       - name: Summary


### PR DESCRIPTION
## Changes


- Pull latest changes before pushing to handle race conditions
- Retry push up to 3 times if it fails
- Prevents 'rejected - fetch first' errors when multiple workflows run

Fixed the issue as shown screen shot

<img width="985" height="801" alt="Screenshot 2026-04-07 at 9 53 26 AM" src="https://github.com/user-attachments/assets/29aab878-7bc2-41fe-a972-3cc88494934b" />


## Checklist

- [ ] Verify on the cluster
- [ ] Update tests if applicable and run `make test`
- [ ] Add screenshots (if applicable)
- [ ] Update readme (if applicable)