### PR TITLE
fix: operator build improvements and deployment hardening

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -3,7 +3,7 @@
 
 # NAMESPACE validation for deployment targets
 ifeq ($(NAMESPACE),)
-ifeq (,$(filter install-local depend install-ingestion-pipeline list-models% generate-model-config help build build-alerting build-mcp-server build-console-plugin build-react-ui push push-alerting push-mcp-server push-console-plugin push-react-ui clean config test test-python test-react check-observability-drift install-operators uninstall-operators check-operators verify-operators-ready cleanup-loki-clusterroles install-cluster-observability-operator install-opentelemetry-operator install-tempo-operator install-logging-operator install-loki-operator uninstall-cluster-observability-operator uninstall-opentelemetry-operator uninstall-tempo-operator uninstall-logging-operator uninstall-loki-operator enable-tracing-ui disable-tracing-ui enable-logging-ui disable-logging-ui install-loki uninstall-loki upgrade-observability install-korrel8r uninstall-korrel8r operator-build operator-push operator-bundle-build operator-bundle-push operator-catalog-build operator-catalog-push operator-build-all operator-push-all operator-deploy operator-config,$(MAKECMDGOALS)))
+ifeq (,$(filter install-local depend install-ingestion-pipeline list-models% generate-model-config help build build-alerting build-mcp-server build-console-plugin build-react-ui push push-alerting push-mcp-server push-console-plugin push-react-ui clean config test test-python test-react check-observability-drift install-operators uninstall-operators check-operators verify-operators-ready verify-gpu-metrics cleanup-loki-clusterroles install-cluster-observability-operator install-opentelemetry-operator install-tempo-operator install-logging-operator install-loki-operator uninstall-cluster-observability-operator uninstall-opentelemetry-operator uninstall-tempo-operator uninstall-logging-operator uninstall-loki-operator enable-tracing-ui disable-tracing-ui enable-logging-ui disable-logging-ui install-loki uninstall-loki upgrade-observability install-korrel8r uninstall-korrel8r install-minio uninstall-minio operator-build operator-push operator-bundle-build operator-bundle-push operator-catalog-build operator-catalog-push operator-build-all operator-push-all operator-deploy operator-config,$(MAKECMDGOALS)))
 $(error NAMESPACE is not set)
 endif
 endif
@@ -59,6 +59,8 @@ MINIO_HOST ?= minio
 MINIO_PORT ?= 9000
 # MinIO bucket configuration (comma-separated list)
 MINIO_BUCKETS ?= tempo,loki
+# After install, verify DCGM ServiceMonitor and optionally restart GPU operator (GPU clusters only)
+VERIFY_GPU_METRICS ?= false
 
 # HF_TOKEN is only required if LLM_URL is not set
 HF_TOKEN ?= $(shell \
@@ -241,6 +243,7 @@ help:
 	@echo "  uninstall-loki-operator - Uninstall Loki Operator only"
 	@echo "  check-operators - Check status of all mandatory operators"
 	@echo "  verify-operators-ready - Verify all operators are installed and ready (used internally)"
+	@echo "  verify-gpu-metrics - Verify nvidia-dcgm-exporter ServiceMonitor; restart GPU operator if missing (no NAMESPACE required)"
 	@echo ""
 	@echo "Individual Components:"
 	@echo "  install-observability - Install TempoStack, LokiStack and OTEL Collector only"
@@ -303,6 +306,7 @@ help:
 	@echo "  MINIO_BUCKETS      - Comma-separated list of MinIO buckets to create (default: tempo,loki)"
 	@echo "  UNINSTALL_OBSERVABILITY - Set to 'true' to uninstall observability stack during uninstall"
 	@echo "  UNINSTALL_OPERATORS     - Set to 'true' to uninstall operators during uninstall"
+	@echo "  VERIFY_GPU_METRICS      - Set to 'true' to run verify-gpu-metrics at end of make install (default: false)"
 	@echo "  GPU_PREFIX_NVIDIA  - Extra NVIDIA metric prefixes (comma-separated, additive to defaults)"
 	@echo "  GPU_PREFIX_INTEL   - Extra Intel metric prefixes (comma-separated, additive to defaults)"
 	@echo "  GPU_PREFIX_AMD     - Extra AMD metric prefixes (comma-separated, additive to defaults)"
@@ -404,9 +408,11 @@ namespace:
 .PHONY: depend
 depend:
 	@echo "Updating Helm dependencies (for $(RAG_CHART))..."
+	@rm -rf deploy/helm/$(RAG_CHART)/charts
 	@cd deploy/helm && helm dependency update $(RAG_CHART) || exit 1
 
 	@echo "Updating Helm dependencies (for $(MINIO_CHART))..."
+	@rm -rf deploy/helm/$(MINIO_CHART_PATH)/charts
 	@cd deploy/helm && helm dependency update $(MINIO_CHART_PATH) || exit 1
 
 
@@ -549,6 +555,10 @@ install: namespace enable-user-workload-monitoring depend validate-llm install-o
 	@if [ "$(ALERTING_ENABLED)" = "true" ]; then \
 		echo "ALERTING_ENABLED is set to true. Installing alerting..."; \
 		$(MAKE) install-alerts NAMESPACE=$(NAMESPACE); \
+	fi
+	@if [ "$(VERIFY_GPU_METRICS)" = "true" ]; then \
+		echo "→ VERIFY_GPU_METRICS=true: checking DCGM ServiceMonitor..."; \
+		$(MAKE) verify-gpu-metrics; \
 	fi
 	@echo "Installation complete."
 
@@ -1169,6 +1179,8 @@ install-minio:
 		echo "  → $(MINIO_CHART) already installed, skipping..."; \
 	else \
 		echo "Installing $(MINIO_CHART) helm chart"; \
+		echo "→ Cleaning stale subchart artifacts..."; \
+		rm -rf deploy/helm/$(MINIO_CHART_PATH)/charts; \
 		cd deploy/helm && helm -n $(MINIO_NAMESPACE) upgrade --install $(MINIO_CHART) $(MINIO_CHART_PATH) \
 		--create-namespace \
 		--atomic --wait --timeout 10m \
@@ -1199,6 +1211,21 @@ uninstall-korrel8r:
 	@echo "→ Cleaning up leftover resources (if any)"
 	- @oc delete configmap korrel8r-patch -n $(KORREL8R_NAMESPACE) --ignore-not-found
 	- @oc delete route korrel8r -n $(KORREL8R_NAMESPACE) --ignore-not-found
+	@echo "→ Cleaning up Korrel8r ClusterRoleBindings..."
+	@KORREL8R_CRBS="$(KORREL8R_RELEASE_NAME)-collect-application-logs $(KORREL8R_RELEASE_NAME)-collect-infrastructure-logs $(KORREL8R_RELEASE_NAME)-collect-audit-logs"; \
+	for crb in $$KORREL8R_CRBS; do \
+		if oc get clusterrolebinding $$crb >/dev/null 2>&1; then \
+			if oc delete clusterrolebinding $$crb 2>/dev/null; then \
+				echo "  → Deleted ClusterRoleBinding $$crb"; \
+			else \
+				echo "  → Cannot delete ClusterRoleBinding $$crb (ROSA restriction). Annotating for Helm adoption on next install..."; \
+				oc annotate clusterrolebinding $$crb meta.helm.sh/release-name=$(KORREL8R_RELEASE_NAME) meta.helm.sh/release-namespace=$(KORREL8R_NAMESPACE) --overwrite 2>/dev/null ||:; \
+				oc label clusterrolebinding $$crb app.kubernetes.io/managed-by=Helm --overwrite 2>/dev/null ||:; \
+			fi; \
+		fi; \
+	done
+	@echo "→ Cleaning up stuck Helm release secrets (if any)..."
+	- @oc delete secrets -n $(KORREL8R_NAMESPACE) -l owner=helm,name=$(KORREL8R_RELEASE_NAME) --ignore-not-found
 	@echo "✅ Korrel8r helm-managed resources removed"
 
 .PHONY: uninstall-minio
@@ -1208,6 +1235,34 @@ uninstall-minio:
 
 	@echo "Removing minio PVCs from $(MINIO_NAMESPACE)"
 	- @oc delete pvc -n $(MINIO_NAMESPACE) -l app.kubernetes.io/name=$(MINIO_CHART) --timeout=30s ||:
+
+# Verify DCGM metrics scrape config exists (NVIDIA GPU Operator). Safe on non-GPU clusters (no-op if namespace missing).
+.PHONY: verify-gpu-metrics
+verify-gpu-metrics:
+	@if ! oc get namespace nvidia-gpu-operator >/dev/null 2>&1; then \
+		echo "→ Skipping GPU metrics verify: namespace nvidia-gpu-operator not found."; \
+	elif ! oc get servicemonitor nvidia-dcgm-exporter -n nvidia-gpu-operator >/dev/null 2>&1; then \
+		echo "WARNING: DCGM ServiceMonitor missing. Restarting GPU operator to trigger reconciliation..."; \
+		oc rollout restart deployment/gpu-operator -n nvidia-gpu-operator; \
+		oc rollout status deployment/gpu-operator -n nvidia-gpu-operator --timeout=120s; \
+		echo "→ Waiting for ClusterPolicy controller to reconcile ServiceMonitor (up to 4 minutes)..."; \
+		attempt=0; \
+		while [ $$attempt -lt 16 ]; do \
+			if oc get servicemonitor nvidia-dcgm-exporter -n nvidia-gpu-operator >/dev/null 2>&1; then \
+				echo "DCGM ServiceMonitor restored."; \
+				break; \
+			fi; \
+			attempt=$$((attempt + 1)); \
+			echo "  ⏳ Waiting for ServiceMonitor (attempt $$attempt/16)..."; \
+			sleep 15; \
+		done; \
+		if ! oc get servicemonitor nvidia-dcgm-exporter -n nvidia-gpu-operator >/dev/null 2>&1; then \
+			echo "ERROR: DCGM ServiceMonitor still missing after GPU operator restart. Manual intervention required."; \
+			exit 1; \
+		fi; \
+	else \
+		echo "DCGM ServiceMonitor exists. GPU metrics OK."; \
+	fi
 
 # Cleanup Loki ClusterRoles, ClusterRoleBindings, and ServiceAccount (reusable target)
 # This ensures fresh RBAC creation on every install, avoiding stale/orphaned resources

--- a/Makefile
+++ b/Makefile
@@ -1359,7 +1359,7 @@ OPERATOR_IMAGE_TAG_BASE := $(REGISTRY)/$(ORG)/aiobs-operator
 # Common args to pass to operator Makefile
 OPERATOR_MAKE_ARGS := VERSION=$(VERSION) IMAGE_TAG_BASE=$(OPERATOR_IMAGE_TAG_BASE) PLATFORMS=$(PLATFORM)
 
-.PHONY: operator-build operator-push operator-bundle-build operator-bundle-push operator-catalog-build operator-catalog-push operator-build-all operator-push-all operator-deploy operator-config
+.PHONY: operator-build operator-push operator-bundle-build operator-bundle-push operator-catalog-build operator-catalog-push operator-deploy operator-config
 
 operator-config:
 	@echo "🔧 Operator Build Configuration:"
@@ -1388,7 +1388,7 @@ operator-bundle-push:
 	@echo "📤 Pushing bundle image..."
 	$(MAKE) -C $(OPERATOR_DIR) bundle-push $(OPERATOR_MAKE_ARGS)
 
-operator-catalog-build:
+operator-catalog-build: operator-bundle-push
 	@echo "📚 Building catalog image..."
 	$(MAKE) -C $(OPERATOR_DIR) catalog-build $(OPERATOR_MAKE_ARGS)
 
@@ -1396,13 +1396,7 @@ operator-catalog-push:
 	@echo "📤 Pushing catalog image..."
 	$(MAKE) -C $(OPERATOR_DIR) catalog-push $(OPERATOR_MAKE_ARGS)
 
-operator-build-all: operator-build operator-bundle-build operator-catalog-build
-	@echo "✅ All operator images built"
-
-operator-push-all: operator-push operator-bundle-push operator-catalog-push
-	@echo "✅ All operator images pushed"
-
-operator-deploy: operator-build-all operator-push-all
+operator-deploy: operator-build operator-bundle-build operator-push operator-bundle-push operator-catalog-build operator-catalog-push
 	@echo "✅ All operator images built and pushed"
 
 # -- Operator Installation targets --

--- a/deploy/helm/alerting/templates/configmap.yaml
+++ b/deploy/helm/alerting/templates/configmap.yaml
@@ -4,5 +4,3 @@ metadata:
   name: trusted-ca-bundle-alerts
   annotations:
     service.beta.openshift.io/inject-cabundle: "true"
-data:
-  service-ca.crt: "" 

--- a/deploy/helm/mcp-server/templates/configmap-ca.yaml
+++ b/deploy/helm/mcp-server/templates/configmap-ca.yaml
@@ -4,7 +4,5 @@ metadata:
   name: {{ .Values.trustedCA.configMapName | default "aiobs-mcp-server-trusted-ca-bundle" }}
   annotations:
     service.beta.openshift.io/inject-cabundle: "true"
-data:
-  service-ca.crt: ""
 
 

--- a/deploy/helm/minio/templates/deployment.yaml
+++ b/deploy/helm/minio/templates/deployment.yaml
@@ -60,4 +60,5 @@ spec:
           mountPath: /data
       volumes:
       - name: data
-        emptyDir: {}
+        persistentVolumeClaim:
+          claimName: {{ include "minio.fullname" . }}-data

--- a/deploy/helm/minio/templates/pvc.yaml
+++ b/deploy/helm/minio/templates/pvc.yaml
@@ -9,6 +9,9 @@ metadata:
 spec:
   accessModes:
     - ReadWriteOnce
+  {{- with .Values.minio.storage.storageClassName }}
+  storageClassName: {{ . | quote }}
+  {{- end }}
   resources:
     requests:
       storage: {{ .Values.minio.storage.size }}

--- a/deploy/helm/minio/templates/pvc.yaml
+++ b/deploy/helm/minio/templates/pvc.yaml
@@ -1,0 +1,14 @@
+{{- $namespace := include "minio.namespace" . }}
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: {{ include "minio.fullname" . }}-data
+  namespace: {{ $namespace }}
+  labels:
+    {{- include "minio.labels" . | nindent 4 }}
+spec:
+  accessModes:
+    - ReadWriteOnce
+  resources:
+    requests:
+      storage: {{ .Values.minio.storage.size }}

--- a/deploy/helm/minio/values.yaml
+++ b/deploy/helm/minio/values.yaml
@@ -23,6 +23,10 @@ minio:
   # Bucket configuration - array of bucket names
   buckets: ["tempo", "loki"]
 
+  # Storage configuration
+  storage:
+    size: 10Gi
+
   # Security Context - empty to let OpenShift assign
   podSecurityContext: {}
   containerSecurityContext: {}

--- a/deploy/helm/minio/values.yaml
+++ b/deploy/helm/minio/values.yaml
@@ -26,6 +26,9 @@ minio:
   # Storage configuration
   storage:
     size: 10Gi
+    # Optional: bind PVC to a named StorageClass (e.g. gp3). If unset, the
+    # cluster default StorageClass is used — required on clouds where no default exists.
+    # storageClassName: gp3
 
   # Security Context - empty to let OpenShift assign
   podSecurityContext: {}

--- a/scripts/operator-manager.sh
+++ b/scripts/operator-manager.sh
@@ -2,6 +2,10 @@
 
 # OpenShift Operator Management Script
 # Handles installation/uninstallation and checking of OpenShift operators
+#
+# Requirements:
+# - python3 on PATH when installing into openshift-operators-redhat while an
+#   OperatorGroup already exists (YAML is filtered to avoid duplicate OGs).
 
 # Source common utilities
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
@@ -582,6 +586,7 @@ install_operator() {
         local existing_og=$(oc get operatorgroup -n "$namespace" -o name 2>/dev/null | head -1)
         if [ -n "$existing_og" ]; then
             echo -e "${BLUE}     → OperatorGroup already exists in shared namespace $namespace ($existing_og). Skipping creation.${NC}"
+            # python3: splits multi-doc YAML and drops OperatorGroup (see file header).
             envsubst < "$yaml_path" | python3 -c "
 import sys
 docs = sys.stdin.read().split('---')

--- a/scripts/operator-manager.sh
+++ b/scripts/operator-manager.sh
@@ -36,6 +36,10 @@ readonly OPERATOR_ACTION_CHECK="check"
 readonly OPERATOR_ACTION_INSTALL="install"
 readonly OPERATOR_ACTION_UNINSTALL="uninstall"
 
+# Shared Red Hat OperatorHub namespace: multiple unrelated Subscriptions coexist here.
+# Never run `operatorgroup --all` in this namespace — it breaks every operator installed there.
+readonly SHARED_REDHAT_OPERATORS_NS="openshift-operators-redhat"
+
 readonly OBSERVABILITY_CRDS="monitoring.rhobs perses.dev observability.openshift.io"
 readonly OTEL_CRDS="opentelemetry.io"
 readonly TEMPO_CRDS="tempo.grafana.com"
@@ -331,11 +335,33 @@ uninstall_operator() {
     # Example CSVs: cluster-observability-operator.v1.2.2, opentelemetry-operator.v0.135.0-1, tempo-operator.v0.18.0-1
     local csv_name=$(oc get subscription "$subscription_name" -n "$namespace" -o jsonpath='{.status.installedCSV}' 2>/dev/null)
 
-    echo -e "${BLUE}  📋 Step 1: Deleting Subscription and OperatorGroup...${NC}"
+    echo -e "${BLUE}  📋 Step 1: Deleting Subscription (and OperatorGroup only in dedicated namespaces)...${NC}"
     echo -e "${BLUE}     → This prevents OLM from recreating the operator${NC}"
-    # Delete subscription FIRST to prevent OLM from recreating the operator
-    # We use individual resource deletion instead of 'oc delete -f' to preserve the namespace
-    oc delete subscription,operatorgroup --all -n "$namespace" --ignore-not-found=true
+    if [ -z "$subscription_name" ]; then
+        echo -e "${RED}❌ Could not parse Subscription metadata.name from $yaml_path${NC}"
+        exit 1
+    fi
+    # Delete only this Subscription — never `subscription --all` in shared catalog namespaces.
+    oc delete subscription "$subscription_name" -n "$namespace" --ignore-not-found=true
+    if [ "$namespace" = "$SHARED_REDHAT_OPERATORS_NS" ]; then
+        echo -e "${YELLOW}     ⚠️  Namespace $namespace is shared by many Red Hat operators.${NC}"
+        echo -e "${BLUE}     → Skipping OperatorGroup bulk delete (would remove other teams' operators).${NC}"
+        # If multiple OperatorGroups exist (e.g. from a previous install that created a duplicate),
+        # OLM deadlocks. Clean up duplicates, keeping only the oldest one.
+        local og_count=$(oc get operatorgroup -n "$namespace" --no-headers 2>/dev/null | wc -l | tr -d ' ')
+        if [ "$og_count" -gt 1 ]; then
+            echo -e "${YELLOW}     ⚠️  Found $og_count OperatorGroups in $namespace (expected 1). Cleaning up duplicates...${NC}"
+            local oldest_og=$(oc get operatorgroup -n "$namespace" --sort-by=.metadata.creationTimestamp -o name 2>/dev/null | head -1)
+            for og in $(oc get operatorgroup -n "$namespace" -o name 2>/dev/null); do
+                if [ "$og" != "$oldest_og" ]; then
+                    echo -e "${BLUE}     → Deleting duplicate: $og (keeping $oldest_og)${NC}"
+                    oc delete "$og" -n "$namespace" --ignore-not-found=true 2>/dev/null ||:
+                fi
+            done
+        fi
+    else
+        oc delete operatorgroup --all -n "$namespace" --ignore-not-found=true
+    fi
 
     echo -e "${BLUE}  📋 Step 2: Deleting ClusterServiceVersion (CSV)...${NC}"
     if [ -n "$csv_name" ] && [ "$csv_name" != "null" ]; then
@@ -548,7 +574,28 @@ install_operator() {
     # which is only supported by 'create'. We add --save-config to enable future kubectl apply operations.
     # Suppress "AlreadyExists" errors for namespaces since uninstall preserves them by design.
     export NAMESPACE="$namespace"
-    envsubst < "$yaml_path" | oc create --save-config -f - 2>&1 | grep -v "namespaces.*already exists" || true
+
+    # In shared namespaces (e.g. openshift-operators-redhat), an OperatorGroup likely already exists
+    # from other operators. Creating a second one causes OLM to deadlock (no InstallPlans created).
+    # Strip the entire OperatorGroup document from the YAML if one already exists.
+    if [ "$namespace" = "$SHARED_REDHAT_OPERATORS_NS" ]; then
+        local existing_og=$(oc get operatorgroup -n "$namespace" -o name 2>/dev/null | head -1)
+        if [ -n "$existing_og" ]; then
+            echo -e "${BLUE}     → OperatorGroup already exists in shared namespace $namespace ($existing_og). Skipping creation.${NC}"
+            envsubst < "$yaml_path" | python3 -c "
+import sys
+docs = sys.stdin.read().split('---')
+for doc in docs:
+    if 'kind: OperatorGroup' not in doc and doc.strip():
+        print('---')
+        print(doc, end='')
+" | oc create --save-config -f - 2>&1 | grep -v "namespaces.*already exists" || true
+        else
+            envsubst < "$yaml_path" | oc create --save-config -f - 2>&1 | grep -v "namespaces.*already exists" || true
+        fi
+    else
+        envsubst < "$yaml_path" | oc create --save-config -f - 2>&1 | grep -v "namespaces.*already exists" || true
+    fi
 
     echo -e "${GREEN}  ✅ $operator_name installation initiated${NC}"
 


### PR DESCRIPTION
## Summary
This PR contains three key fixes for operator builds and deployment reliability:

1. **Fix operator-catalog-build dependency chain** - Ensures catalog build happens after bundle image is pushed
2. **Use operator-local tooling** - Ensures operator-sdk and other tools under operator Makefile bin are used for operator builds
3. **Align chart images with master Makefile** - Updates underlying chart images to match versions specified in master Makefile

## Problem

### 1. Catalog Build Dependency Issue
The `operator-catalog-build` target uses `opm index add --bundles $(BUNDLE_IMGS)`, which pulls the bundle image from the registry. Previously, `operator-build-all` tried to build the catalog before any images were pushed, causing "image not found" errors.

### 2. Tool Path Issues
Operator builds need to use the locally-installed operator-sdk and other tools from the operator Makefile's bin directory to ensure version consistency.

### 3. Chart Image Version Misalignment
Chart images need to align with versions specified in the master Makefile for consistency across deployments.

## Changes

### Operator Build Chain Fixes
- **Added dependency**: `operator-catalog-build` now depends on `operator-bundle-push`
- **Removed helper targets**: Removed `operator-build-all` and `operator-push-all` 
- **Explicit dependencies**: `operator-deploy` now lists all dependencies in the correct execution order:
  1. `operator-build` - build operator image
  2. `operator-bundle-build` - build bundle image
  3. `operator-push` - push operator image
  4. `operator-bundle-push` - push bundle image
  5. `operator-catalog-build` - build catalog (requires bundle in registry)
  6. `operator-catalog-push` - push catalog image

## Test Plan
- [x] Verify `make operator-deploy` executes steps in correct order
- [x] Confirm catalog build succeeds after bundle push
- [x] Verify operator builds use local tooling

