### PR TITLE
fix: handle unstaged changes in operator manifest workflow

### DIFF
--- a/.github/workflows/build-operator-images.yml
+++ b/.github/workflows/build-operator-images.yml
@@ -94,8 +94,9 @@ jobs:
         if: ${{ inputs.push_changes }}
         run: |
           # Add all files updated by make bundle and catalog image update
+          # Use git add -A to catch any files created by bundle generation
           git add deploy/operator/catalog-source.yaml
-          git add deploy/operator/bundle/manifests/aiobs-operator.clusterserviceversion.yaml
+          git add deploy/operator/bundle/
           git add deploy/operator/config/manager/kustomization.yaml
 
           if git diff --staged --quiet; then
@@ -112,9 +113,24 @@ jobs:
           EOF
           )"
 
+            # Stash any remaining unstaged changes before pulling
+            if ! git diff --quiet || ! git diff --cached --quiet; then
+              echo "Stashing unstaged changes..."
+              git stash push -u -m "temp stash before pull"
+              STASHED=true
+            else
+              STASHED=false
+            fi
+
             # Pull latest changes before pushing (handles race conditions)
             echo "Pulling latest changes..."
             git pull --rebase origin ${GITHUB_REF#refs/heads/}
+
+            # Pop stash if we stashed
+            if [ "$STASHED" = "true" ]; then
+              echo "Restoring stashed changes..."
+              git stash pop || true
+            fi
 
             # Push with retry logic
             echo "Pushing changes..."


### PR DESCRIPTION
## Problem
The `build-operator-images` workflow fails with:
```
error: cannot pull with rebase: You have unstaged changes.
error: Please commit or stash them.
```

## Root Cause
After `make bundle` runs, it may create or modify files beyond the 3 we explicitly add to git. When we try to `git pull --rebase`, git refuses due to unstaged changes.

## Solution
- Add entire `bundle/` directory instead of just the CSV file
- Stash any unstaged changes before `git pull --rebase`
- Pop stash after pull completes

## Testing
- [x] Dry-run completed successfully
- [ ] Needs testing with real release workflow

Fixes the operator manifest commit/push step.