### PR TITLE
feat: add automatic operator image builds on PR merge

### DIFF
--- a/.github/workflows/build-and-push.yml
+++ b/.github/workflows/build-and-push.yml
@@ -179,3 +179,15 @@ jobs:
       push_changes: true
       target_branch: ${{ github.ref_name }}
     secrets: inherit
+
+  build-operator:
+    name: Build and Push operator images
+    needs: [semantic-version, build-image]
+    if: (github.event_name == 'push' && github.ref_name != 'main') || github.event_name == 'workflow_dispatch'
+    uses: ./.github/workflows/build-operator-images.yml
+    with:
+      version: ${{ needs.semantic-version.outputs.version }}
+      registry: quay.io
+      org: ecosystem-appeng
+      push_changes: true
+    secrets: inherit


### PR DESCRIPTION
- Add build-operator job to build-and-push.yml workflow
- Operator images (operator, bundle, catalog) now build automatically when PRs merge to dev
- Keeps operator images in sync with app images using same semantic version
- Maintains same configuration as prepare-release workflow

## Changes

- <!-- Describe the main changes -->
- <!-- List other relevant modifications -->

## Checklist

- [ ] Verify on the cluster
- [ ] Update tests if applicable and run `make test`
- [ ] Add screenshots (if applicable)
- [ ] Update readme (if applicable)