### PR TITLE
fix: remove CRD deletion during operator uninstall to prevent DCGM ServiceMonitor loss

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -3,7 +3,7 @@
 
 # NAMESPACE validation for deployment targets
 ifeq ($(NAMESPACE),)
-ifeq (,$(filter install-local depend install-ingestion-pipeline list-models% generate-model-config help build build-alerting build-mcp-server build-console-plugin build-react-ui push push-alerting push-mcp-server push-console-plugin push-react-ui clean config test test-python test-react check-observability-drift install-operators uninstall-operators check-operators verify-operators-ready verify-gpu-metrics cleanup-loki-clusterroles install-cluster-observability-operator install-opentelemetry-operator install-tempo-operator install-logging-operator install-loki-operator uninstall-cluster-observability-operator uninstall-opentelemetry-operator uninstall-tempo-operator uninstall-logging-operator uninstall-loki-operator enable-tracing-ui disable-tracing-ui enable-logging-ui disable-logging-ui install-loki uninstall-loki upgrade-observability install-korrel8r uninstall-korrel8r install-minio uninstall-minio operator-build operator-push operator-bundle-build operator-bundle-push operator-catalog-build operator-catalog-push operator-build-all operator-push-all operator-deploy operator-config,$(MAKECMDGOALS)))
+ifeq (,$(filter install-local depend install-ingestion-pipeline list-models% generate-model-config help build build-alerting build-mcp-server build-console-plugin build-react-ui push push-alerting push-mcp-server push-console-plugin push-react-ui clean config test test-python test-react check-observability-drift install-operators uninstall-operators check-operators verify-operators-ready cleanup-loki-clusterroles install-cluster-observability-operator install-opentelemetry-operator install-tempo-operator install-logging-operator install-loki-operator uninstall-cluster-observability-operator uninstall-opentelemetry-operator uninstall-tempo-operator uninstall-logging-operator uninstall-loki-operator enable-tracing-ui disable-tracing-ui enable-logging-ui disable-logging-ui install-loki uninstall-loki upgrade-observability install-korrel8r uninstall-korrel8r install-minio uninstall-minio operator-build operator-push operator-bundle-build operator-bundle-push operator-catalog-build operator-catalog-push operator-build-all operator-push-all operator-deploy operator-config,$(MAKECMDGOALS)))
 $(error NAMESPACE is not set)
 endif
 endif
@@ -59,8 +59,6 @@ MINIO_HOST ?= minio
 MINIO_PORT ?= 9000
 # MinIO bucket configuration (comma-separated list)
 MINIO_BUCKETS ?= tempo,loki
-# After install, verify DCGM ServiceMonitor and optionally restart GPU operator (GPU clusters only)
-VERIFY_GPU_METRICS ?= false
 
 # HF_TOKEN is only required if LLM_URL is not set
 HF_TOKEN ?= $(shell \
@@ -243,7 +241,6 @@ help:
 	@echo "  uninstall-loki-operator - Uninstall Loki Operator only"
 	@echo "  check-operators - Check status of all mandatory operators"
 	@echo "  verify-operators-ready - Verify all operators are installed and ready (used internally)"
-	@echo "  verify-gpu-metrics - Verify nvidia-dcgm-exporter ServiceMonitor; restart GPU operator if missing (no NAMESPACE required)"
 	@echo ""
 	@echo "Individual Components:"
 	@echo "  install-observability - Install TempoStack, LokiStack and OTEL Collector only"
@@ -306,7 +303,6 @@ help:
 	@echo "  MINIO_BUCKETS      - Comma-separated list of MinIO buckets to create (default: tempo,loki)"
 	@echo "  UNINSTALL_OBSERVABILITY - Set to 'true' to uninstall observability stack during uninstall"
 	@echo "  UNINSTALL_OPERATORS     - Set to 'true' to uninstall operators during uninstall"
-	@echo "  VERIFY_GPU_METRICS      - Set to 'true' to run verify-gpu-metrics at end of make install (default: false)"
 	@echo "  GPU_PREFIX_NVIDIA  - Extra NVIDIA metric prefixes (comma-separated, additive to defaults)"
 	@echo "  GPU_PREFIX_INTEL   - Extra Intel metric prefixes (comma-separated, additive to defaults)"
 	@echo "  GPU_PREFIX_AMD     - Extra AMD metric prefixes (comma-separated, additive to defaults)"
@@ -555,10 +551,6 @@ install: namespace enable-user-workload-monitoring depend validate-llm install-o
 	@if [ "$(ALERTING_ENABLED)" = "true" ]; then \
 		echo "ALERTING_ENABLED is set to true. Installing alerting..."; \
 		$(MAKE) install-alerts NAMESPACE=$(NAMESPACE); \
-	fi
-	@if [ "$(VERIFY_GPU_METRICS)" = "true" ]; then \
-		echo "→ VERIFY_GPU_METRICS=true: checking DCGM ServiceMonitor..."; \
-		$(MAKE) verify-gpu-metrics; \
 	fi
 	@echo "Installation complete."
 
@@ -1235,34 +1227,6 @@ uninstall-minio:
 
 	@echo "Removing minio PVCs from $(MINIO_NAMESPACE)"
 	- @oc delete pvc -n $(MINIO_NAMESPACE) -l app.kubernetes.io/name=$(MINIO_CHART) --timeout=30s ||:
-
-# Verify DCGM metrics scrape config exists (NVIDIA GPU Operator). Safe on non-GPU clusters (no-op if namespace missing).
-.PHONY: verify-gpu-metrics
-verify-gpu-metrics:
-	@if ! oc get namespace nvidia-gpu-operator >/dev/null 2>&1; then \
-		echo "→ Skipping GPU metrics verify: namespace nvidia-gpu-operator not found."; \
-	elif ! oc get servicemonitor nvidia-dcgm-exporter -n nvidia-gpu-operator >/dev/null 2>&1; then \
-		echo "WARNING: DCGM ServiceMonitor missing. Restarting GPU operator to trigger reconciliation..."; \
-		oc rollout restart deployment/gpu-operator -n nvidia-gpu-operator; \
-		oc rollout status deployment/gpu-operator -n nvidia-gpu-operator --timeout=120s; \
-		echo "→ Waiting for ClusterPolicy controller to reconcile ServiceMonitor (up to 4 minutes)..."; \
-		attempt=0; \
-		while [ $$attempt -lt 16 ]; do \
-			if oc get servicemonitor nvidia-dcgm-exporter -n nvidia-gpu-operator >/dev/null 2>&1; then \
-				echo "DCGM ServiceMonitor restored."; \
-				break; \
-			fi; \
-			attempt=$$((attempt + 1)); \
-			echo "  ⏳ Waiting for ServiceMonitor (attempt $$attempt/16)..."; \
-			sleep 15; \
-		done; \
-		if ! oc get servicemonitor nvidia-dcgm-exporter -n nvidia-gpu-operator >/dev/null 2>&1; then \
-			echo "ERROR: DCGM ServiceMonitor still missing after GPU operator restart. Manual intervention required."; \
-			exit 1; \
-		fi; \
-	else \
-		echo "DCGM ServiceMonitor exists. GPU metrics OK."; \
-	fi
 
 # Cleanup Loki ClusterRoles, ClusterRoleBindings, and ServiceAccount (reusable target)
 # This ensures fresh RBAC creation on every install, avoiding stale/orphaned resources

--- a/scripts/operator-manager.sh
+++ b/scripts/operator-manager.sh
@@ -377,71 +377,14 @@ uninstall_operator() {
         echo -e "${BLUE}       oc delete csv -n $namespace --all --ignore-not-found=true${NC}"
     fi
 
-    echo -e "${BLUE}  📋 Step 3: Deleting CRD resources and CRDs to prevent operator resurrection...${NC}"
-    # Get CRD patterns for this operator
-    local crd_patterns=$(get_operator_crds "$operator_name")
-    if [ -n "$crd_patterns" ]; then
-        for pattern in $crd_patterns; do
-            echo -e "${BLUE}     → Finding CRDs matching pattern: $pattern${NC}"
-            local crds=$(oc get crd -o name | grep "$pattern" | cut -d'/' -f2)
-            if [ -n "$crds" ]; then
-                # First, delete all resources of each CRD type
-                for crd in $crds; do
-                    echo -e "${BLUE}     → Deleting all resources of type: $crd${NC}"
-                    # Get the resource kind from CRD (plural name without domain)
-                    local resource_kind=$(echo "$crd" | cut -d'.' -f1)
+    # CRDs are intentionally NOT deleted during uninstall. This follows standard OLM
+    # practice: CRD deletion is cascading (deletes all custom resources cluster-wide),
+    # CRDs may be shared across operators, and keeping them preserves data for reinstall.
+    # Previously, deleting CRDs here caused collateral damage — e.g., deleting
+    # servicemonitors.monitoring.rhobs also resolved to servicemonitors.monitoring.coreos.com,
+    # wiping GPU operator DCGM ServiceMonitors and all platform ServiceMonitors.
 
-                    # Check if CRD is cluster-scoped or namespaced
-                    local crd_scope=$(oc get crd "$crd" -o jsonpath='{.spec.scope}' 2>/dev/null || echo "Namespaced")
-
-                    # Delete all resources of this type across all namespaces
-                    local resources=$(oc get "$resource_kind" --all-namespaces -o name 2>/dev/null || true)
-                    if [ -n "$resources" ]; then
-                        echo -e "${BLUE}        → Found resources: $resources${NC}"
-                        oc delete "$resource_kind" --all --all-namespaces --ignore-not-found=true --timeout=30s 2>/dev/null || true
-
-                        # Check if resources still exist (stuck with finalizers)
-                        if [ "$crd_scope" = "Cluster" ]; then
-                            # Cluster-scoped: output is "NAME AGE", so $1 is the name
-                            local remaining=$(oc get "$resource_kind" --no-headers -o custom-columns=NAME:.metadata.name 2>/dev/null || true)
-                            if [ -n "$remaining" ]; then
-                                echo -e "${YELLOW}        → Some cluster-scoped resources still exist (likely stuck with finalizers)${NC}"
-                                echo -e "${BLUE}        → Removing finalizers to force deletion...${NC}"
-                                while read -r name; do
-                                    [ -z "$name" ] && continue
-                                    echo -e "${BLUE}           → Patching cluster-scoped: $name${NC}"
-                                    oc patch "$resource_kind" "$name" --type json -p='[{"op": "remove", "path": "/metadata/finalizers"}]' 2>/dev/null || true
-                                done <<< "$remaining"
-                            fi
-                        else
-                            # Namespaced: output is "NAMESPACE NAME AGE", so $1:$2 is namespace:name
-                            local remaining=$(oc get "$resource_kind" --all-namespaces --no-headers -o custom-columns=NS:.metadata.namespace,NAME:.metadata.name 2>/dev/null | awk '{print $1 ":" $2}' || true)
-                            if [ -n "$remaining" ]; then
-                                echo -e "${YELLOW}        → Some namespaced resources still exist (likely stuck with finalizers)${NC}"
-                                echo -e "${BLUE}        → Removing finalizers to force deletion...${NC}"
-                                while IFS=: read -r ns name; do
-                                    [ -z "$name" ] && continue
-                                    echo -e "${BLUE}           → Patching $ns/$name${NC}"
-                                    oc patch "$resource_kind" "$name" -n "$ns" --type json -p='[{"op": "remove", "path": "/metadata/finalizers"}]' 2>/dev/null || true
-                                done <<< "$remaining"
-                            fi
-                        fi
-                    fi
-                done
-
-                # Now delete the CRDs after resources are removed
-                echo -e "${BLUE}     → Deleting CRDs: $crds${NC}"
-                echo "$crds" | xargs -r oc delete crd --ignore-not-found=true
-            else
-                echo -e "${YELLOW}     ⚠️  No CRDs found matching pattern: $pattern${NC}"
-            fi
-        done
-    else
-        echo -e "${YELLOW}  ⚠️  No CRD patterns defined for operator $operator_name${NC}"
-        echo -e "${YELLOW}  ⚠️  You may need to manually delete CRDs to fully remove the operator${NC}"
-    fi
-
-    echo -e "${BLUE}  📋 Step 4: Deleting operator resource: $operator_name${NC}"
+    echo -e "${BLUE}  📋 Step 3: Deleting operator resource: $operator_name${NC}"
     # Delete the operator resource directly
     oc delete operator "$operator_name" --ignore-not-found=true --wait=false
 


### PR DESCRIPTION
## Summary

  - Remove the CRD deletion step (Step 3) from `uninstall_operator()` in `operator-manager.sh`, replacing it with a comment explaining why CRDs are intentionally preserved — following standard OLM practice
  - Remove the `verify-gpu-metrics` Makefile target and all references (`VERIFY_GPU_METRICS` variable, help text, conditional call in `install`), since the root cause is now eliminated

  ## Problem

  Running `make uninstall-operators` deleted all 3 NVIDIA GPU operator ServiceMonitors (`nvidia-dcgm-exporter`, `gpu-operator`, `nvidia-node-status-exporter`) from the `nvidia-gpu-operator` namespace.

  The `uninstall_operator()` function had a step that deleted CRD instances before removing CRDs. It extracted the resource kind using `cut -d'.' -f1`, turning `servicemonitors.monitoring.rhobs` into the short name `servicemonitors`. On OpenShift, this short name resolves to both `monitoring.rhobs` (Cluster Observability Operator) and `monitoring.coreos.com` (platform Prometheus Operator), so `oc delete servicemonitors --all --all-namespaces` wiped resources from both API groups — including GPU operator DCGM ServiceMonitors and all platform ServiceMonitors.

  Beyond the name collision, CRD deletion during uninstall is not standard OLM practice: it cascades to all custom resources cluster-wide, CRDs may be shared across operators, and keeping them preserves data for reinstall.


  ## Test plan

  - [x] Run `make uninstall-operators` and verify GPU operator ServiceMonitors are preserved (`oc get servicemonitor -n nvidia-gpu-operator`)
  - [x] Run `make install-operators` followed by `make uninstall-operators` — confirm GPU ServiceMonitor UIDs remain constant
  - [x] Verify `grep -n "verify-gpu-metrics\|VERIFY_GPU_METRICS\|DCGM\|nvidia-gpu" Makefile` returns zero results
  - [x] Verify `operator-manager.sh` has no executable CRD deletion code in `uninstall_operator()`
  - [x] Run a full install/uninstall cycle and confirm platform ServiceMonitor count is stable

## Checklist

- [x] Verify on the cluster
- [ ] Update tests if applicable and run `make test`
- [ ] Add screenshots (if applicable)
- [ ] Update readme (if applicable)

Detailed information about the error/fix as well as testing done to confirm the fix works is provided in [this gist](https://gist.github.com/sgahlot/fa416961e44439a21a738521f3e90b67).