### PR TITLE
fix: smart cleanup of grafana-prometheus-reader based on ownership

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -623,8 +623,13 @@ uninstall:
 	@echo "→ Cleaning up grafana-prometheus-reader ClusterRole and binding..."
 	@MCP_CRB="grafana-prometheus-reader-binding-$(NAMESPACE)-mcp"; \
 	if oc get clusterrolebinding $$MCP_CRB >/dev/null 2>&1; then \
-		echo "  → Deleting ClusterRoleBinding $$MCP_CRB"; \
-		oc delete clusterrolebinding $$MCP_CRB --ignore-not-found 2>/dev/null ||:; \
+		OWNER=$$(oc get clusterrolebinding $$MCP_CRB -o jsonpath='{.metadata.annotations.meta\.helm\.sh/release-name}' 2>/dev/null); \
+		if [ "$$OWNER" = "$(MCP_SERVER_RELEASE_NAME)" ] || [ -z "$$OWNER" ]; then \
+			echo "  → Deleting ClusterRoleBinding $$MCP_CRB (owned by: $$OWNER)"; \
+			oc delete clusterrolebinding $$MCP_CRB --ignore-not-found 2>/dev/null ||:; \
+		else \
+			echo "  → Skipping ClusterRoleBinding $$MCP_CRB (owned by '$$OWNER', not $(MCP_SERVER_RELEASE_NAME))"; \
+		fi; \
 	fi
 	@echo "  → Checking if grafana-prometheus-reader ClusterRole should be deleted..."
 	@if oc get clusterrole grafana-prometheus-reader >/dev/null 2>&1; then \
@@ -1267,13 +1272,39 @@ uninstall-minio:
 	@echo "Removing minio PVCs from $(MINIO_NAMESPACE)"
 	- @oc delete pvc -n $(MINIO_NAMESPACE) -l app.kubernetes.io/name=$(MINIO_CHART) --timeout=30s ||:
 
-# Cleanup Loki ClusterRoles, ClusterRoleBindings, and ServiceAccount (reusable target)
-# This ensures fresh RBAC creation on every install, avoiding stale/orphaned resources
+# Cleanup Loki RBAC resources created by our Helm installation
+# NOTE: ClusterRoles are owned by cluster-logging operator - we never delete them
+# We only clean up ClusterRoleBindings and ServiceAccount created by our loki-stack release
+# Resources created by operator (different release name) are left alone
 .PHONY: cleanup-loki-clusterroles
 cleanup-loki-clusterroles:
-	- @oc delete clusterrole logging-collector-logs-writer collect-application-logs collect-audit-logs collect-infrastructure-logs --ignore-not-found 2>/dev/null ||:
-	- @oc delete clusterrolebinding logging-collector-logs-writer collect-application-logs collect-audit-logs collect-infrastructure-logs --ignore-not-found 2>/dev/null ||:
-	- @oc delete serviceaccount collector -n $(LOKI_NAMESPACE) --ignore-not-found 2>/dev/null ||:
+	@echo "  → Checking Loki ClusterRoleBinding ownership before cleanup..."
+	@for crb in logging-collector-logs-writer collect-application-logs collect-audit-logs collect-infrastructure-logs; do \
+		if oc get clusterrolebinding $$crb >/dev/null 2>&1; then \
+			OWNER=$$(oc get clusterrolebinding $$crb -o jsonpath='{.metadata.annotations.meta\.helm\.sh/release-name}' 2>/dev/null); \
+			if [ "$$OWNER" = "loki-stack" ]; then \
+				echo "  → Deleting ClusterRoleBinding $$crb (created by make install - release: loki-stack)"; \
+				oc delete clusterrolebinding $$crb --ignore-not-found 2>/dev/null ||:; \
+			elif [ -n "$$OWNER" ]; then \
+				echo "  → Skipping ClusterRoleBinding $$crb (owned by '$$OWNER', not loki-stack)"; \
+			else \
+				echo "  → Skipping ClusterRoleBinding $$crb (no Helm ownership - likely cluster-logging operator)"; \
+			fi; \
+		fi; \
+	done
+	@echo "  → Checking Loki collector ServiceAccount ownership before cleanup..."
+	@if oc get serviceaccount collector -n $(LOKI_NAMESPACE) >/dev/null 2>&1; then \
+		OWNER=$$(oc get serviceaccount collector -n $(LOKI_NAMESPACE) -o jsonpath='{.metadata.annotations.meta\.helm\.sh/release-name}' 2>/dev/null); \
+		if [ "$$OWNER" = "loki-stack" ]; then \
+			echo "  → Deleting ServiceAccount collector (created by make install - release: loki-stack)"; \
+			oc delete serviceaccount collector -n $(LOKI_NAMESPACE) --ignore-not-found 2>/dev/null ||:; \
+		elif [ -n "$$OWNER" ]; then \
+			echo "  → Skipping ServiceAccount collector (owned by '$$OWNER', not loki-stack)"; \
+		else \
+			echo "  → Skipping ServiceAccount collector (no Helm ownership - likely cluster-logging operator)"; \
+		fi; \
+	fi
+	@echo "  → Loki RBAC cleanup complete (ClusterRoles left intact - owned by cluster-logging operator)"
 
 .PHONY: install-loki
 install-loki:

--- a/Makefile
+++ b/Makefile
@@ -620,6 +620,27 @@ uninstall:
 
 	@echo "Uninstalling $(MCP_SERVER_RELEASE_NAME) helm chart (if installed)"
 	- @helm -n $(NAMESPACE) uninstall $(MCP_SERVER_RELEASE_NAME) --ignore-not-found
+	@echo "→ Cleaning up grafana-prometheus-reader ClusterRole and binding..."
+	@MCP_CRB="grafana-prometheus-reader-binding-$(NAMESPACE)-mcp"; \
+	if oc get clusterrolebinding $$MCP_CRB >/dev/null 2>&1; then \
+		echo "  → Deleting ClusterRoleBinding $$MCP_CRB"; \
+		oc delete clusterrolebinding $$MCP_CRB --ignore-not-found 2>/dev/null ||:; \
+	fi
+	@echo "  → Checking if grafana-prometheus-reader ClusterRole should be deleted..."
+	@if oc get clusterrole grafana-prometheus-reader >/dev/null 2>&1; then \
+		OWNER=$$(oc get clusterrole grafana-prometheus-reader -o jsonpath='{.metadata.annotations.meta\.helm\.sh/release-name}' 2>/dev/null); \
+		if [ "$$OWNER" = "$(MCP_SERVER_RELEASE_NAME)" ]; then \
+			REMAINING_BINDINGS=$$(oc get clusterrolebindings -o json 2>/dev/null | jq -r '.items[] | select(.roleRef.name=="grafana-prometheus-reader") | .metadata.name' 2>/dev/null | wc -l); \
+			if [ "$$REMAINING_BINDINGS" -eq 0 ]; then \
+				echo "  → ClusterRole was created by make install and no other bindings exist. Deleting..."; \
+				oc delete clusterrole grafana-prometheus-reader --ignore-not-found 2>/dev/null ||:; \
+			else \
+				echo "  → ClusterRole still in use by $$REMAINING_BINDINGS binding(s). Skipping deletion."; \
+			fi; \
+		else \
+			echo "  → ClusterRole owned by '$$OWNER' (not $(MCP_SERVER_RELEASE_NAME)). Skipping deletion."; \
+		fi; \
+	fi
 	@echo "Uninstalling UI components (both Console Plugin and React UI if they exist)"
 	@$(MAKE) uninstall-console-plugin NAMESPACE=$(NAMESPACE) || true
 	@$(MAKE) uninstall-react-ui NAMESPACE=$(NAMESPACE) || true


### PR DESCRIPTION
## Summary                                                                                                                                                                                     
                                                                                                                                                                                                 
  Adds ownership-based cleanup logic to `make uninstall` to prevent accidental deletion of shared cluster resources. Previously, `make uninstall` would blindly delete ClusterRoles and          
  ClusterRoleBindings without checking who created them, potentially breaking other installations (operator-based or cluster-logging operator).
                                                                                                                                                                                                 
  ## Changes                                                                                                                                                                                     
   
  ### 1. grafana-prometheus-reader ClusterRole cleanup                                                                                                                                           
  - Checks `meta.helm.sh/release-name` annotation to verify ownership
  - Only deletes if created by `make install` (release: `mcp-server`)                                                                                                                            
  - Verifies no other ClusterRoleBindings are using the ClusterRole before deletion                                                                                                              
  - Skips deletion if owned by operator or other systems                                                                                                                                         
                                                                                                                                                                                                 
  ### 2. MCP ClusterRoleBinding cleanup                                                                                                                                                          
  - Added ownership check for `grafana-prometheus-reader-binding-{namespace}-mcp`                                                                                                                
  - Only deletes if owned by `$(MCP_SERVER_RELEASE_NAME)` or no owner exists                                                                                                                     
  - Prevents deletion of operator-created bindings                                                                                                                                               
                                                                                                                                                                                                 
  ### 3. Loki RBAC cleanup                                                                                                                                                                       
  - **ClusterRoles**: Never deleted (owned by cluster-logging operator)                                                                                                                          
  - **ClusterRoleBindings**: Only deleted if created by `make install` (release: `loki-stack`)                                                                                                   
  - **ServiceAccount**: Only deleted if created by `make install` (release: `loki-stack`)
  - Skips resources created by operator (release: `cluster-ai-observability`) or cluster-logging operator (no Helm ownership)                                                                    
                                                                                                                                                                                                 
  ## Behavior                                                                                                                                                                                    
                                                                                                                                                                                                 
  ### Before                                                                                                                                                                                     
  ```bash                   
  make uninstall
  # Blindly deleted all ClusterRoles/ClusterRoleBindings
  # Could break operator installations or cluster-logging operator
                                                                                                                                                                                                 
  After
                                                                                                                                                                                                 
  make uninstall            
  # Checks ownership before deletion:
    → Deleting ClusterRoleBinding collect-application-logs (created by make install - release: loki-stack)
    → Skipping ClusterRoleBinding collect-audit-logs (owned by 'cluster-ai-observability', not loki-stack)                                                                                       
    → Skipping ClusterRole collect-infrastructure-logs (no Helm ownership - likely cluster-logging operator)                                                                                     
                                                                                                                                                                                                 
  Testing                                                                                                                                                                                        
                                                                                                                                                                                                 
  Run make uninstall UNINSTALL_OPERATORS=true UNINSTALL_OBSERVABILITY=true and verify:                                                                                                           
  - ✅ Only resources created by make install are deleted
  - ✅ OResoueces crsated by operator are skipped d                                                                                                                                              ─
  - ✅ Resources created by ocluster-logging oedrator are skipped
  - ✅ RClear logcmessages showing what was delrted and why                                                                                                                                      ─
      C     l   m        s       w    w   d       a   w   
  Fixes                                                                                                                                                                                          
                                                                                                                                                                                                 
  Prevents make uninstall from breaking:                                                                                                                                                         
  - Operator-based installations                                                                                                                                                                 
  - cluster-logging operator functionality                                                                                                                                                       
  - Other applications sharing cluster resources
                                                             