### PR TITLE
fix: anchor VERSION sed pattern to prevent RHOAI_VERSION corruption

### DIFF
--- a/.github/workflows/update-versions.yml
+++ b/.github/workflows/update-versions.yml
@@ -71,9 +71,11 @@ jobs:
           fi
 
       - name: Update Makefile version
+        # NOTE: Anchor with ^ to match only the VERSION line, not RHOAI_VERSION
+        # or any other variable whose name ends in VERSION.
         run: |
           if [ -f "Makefile" ]; then
-            sed -i 's|VERSION ?= .*|VERSION ?= '"${{ inputs.version }}"'|' Makefile
+            sed -i 's|^VERSION ?= .*|VERSION ?= '"${{ inputs.version }}"'|' Makefile
             echo "Updated Makefile"
           fi
 


### PR DESCRIPTION
## Summary

- Fix overly broad sed pattern in `update-versions.yml` that corrupts `RHOAI_VERSION` on every automated version bump
- The pattern `VERSION ?= .*` matches both `VERSION ?= ...` and `RHOAI_VERSION ?= ...`, overwriting the latter from `2` to the release version (e.g., `5.0.0`)
- Anchor with `^` so only lines **starting with** `VERSION` are matched

## Root cause

Same class of bug fixed in #250 (commit `84edb5e`) for Helm `tag:` values — the Makefile sed was missed in that fix.

## Impact

When `RHOAI_VERSION` is set to `5.0.0` instead of `2`:
- The RHOAI version auto-detection falls through (not `2`, not `3`)
- Logging/Loki operators install with `stable-6.3` channel instead of the correct `stable-6.4` on RHOAI 3.x clusters
- The cluster-logging operator (6.4.x) creates ClusterRoles that conflict with the Helm chart on reinstall

## Test plan

- [ ] Verify `RHOAI_VERSION` line is unchanged after running the update-versions workflow
- [ ] Verify `VERSION` line is correctly updated
- [x] Run install/uninstall cycle on RHOAI 3.x cluster with `RHOAI_VERSION=3`
