### PR TITLE
fix: resolve Loki ClusterRole conflict between OLM and Helm on clean installs

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -18,7 +18,7 @@ VERSION ?= 5.0.0
 PLATFORM ?= linux/amd64
 DEV_MODE ?= false
 USE_LLAMA_STACK_OPERATOR ?= false
-RHOAI_VERSION ?= 5.0.0
+RHOAI_VERSION ?= 2
 
 # GPU Metrics Discovery - custom prefix overrides (comma-separated, additive)
 GPU_PREFIX_NVIDIA ?=
@@ -1078,7 +1078,7 @@ install-observability:
 			--create-namespace \
 			--wait --timeout 10m \
 			--set global.namespace=$(OBSERVABILITY_NAMESPACE) \
-			$(helm_tempo_args); \
+			$(helm_tempo_args) && \
 		echo "  ✅ TempoStack deployed and ready"; \
 	fi
 
@@ -1090,7 +1090,7 @@ install-observability:
 			--namespace $(OBSERVABILITY_NAMESPACE) \
 			--create-namespace \
 			--wait --timeout 10m \
-			--set global.namespace=$(OBSERVABILITY_NAMESPACE); \
+			--set global.namespace=$(OBSERVABILITY_NAMESPACE) && \
 		echo "  ✅ OpenTelemetry Collector deployed and ready"; \
 	fi
 
@@ -1359,7 +1359,7 @@ install-minio:
 		cd deploy/helm && helm -n $(MINIO_NAMESPACE) upgrade --install $(MINIO_CHART) $(MINIO_CHART_PATH) \
 		--create-namespace \
 		--atomic --wait --timeout 10m \
-		$(MINIO_ARGS); \
+		$(MINIO_ARGS) && \
 		echo "  ✅ $(MINIO_CHART) deployed and ready"; \
 	fi
 	@echo "→ Cleaning up broken upstream routes (pointing to non-existent 'minio' service)"
@@ -1483,7 +1483,7 @@ install-loki:
 		else \
 			echo "  ✅ LokiStack CRD is available"; \
 		fi; \
-		echo "→ Cleaning up any pre-existing ClusterRoles that might conflict..."; \
+		echo "→ Cleaning up any pre-existing Helm-owned ClusterRoleBindings/ServiceAccount..."; \
 		$(MAKE) cleanup-loki-clusterroles; \
 		echo "  ✅ Cleanup complete"; \
 		echo "→ Installing loki-stack helm chart"; \
@@ -1505,7 +1505,7 @@ install-loki:
 			--set global.namespace=$(LOKI_NAMESPACE) \
 			--set rbac.collector.create=$$COLLECTOR_CREATE \
 			--set lokiStack.storageClassName=$$DEFAULT_SC \
-			$(helm_loki_args); \
+			$(helm_loki_args) && \
 		echo "✅ loki-stack installed successfully"; \
 	fi
 	@$(MAKE) enable-logging-ui

--- a/deploy/helm/observability/loki/templates/collector-rbac.yaml
+++ b/deploy/helm/observability/loki/templates/collector-rbac.yaml
@@ -4,8 +4,9 @@
 Collector Service Account and RBAC for OpenShift Logging.
 This creates the necessary service account and permissions for log collection.
 
-NOTE: Set rbac.collector.create=false if using OLM-managed Logging Operator,
-as it will create these resources automatically.
+The collector ClusterRoles are provided by the cluster-logging operator bundle
+(installed via OLM) and are NOT created here. Only the ServiceAccount and
+ClusterRoleBindings are managed by this chart.
 */}}
 
 {{/* ServiceAccount */}}
@@ -19,84 +20,6 @@ metadata:
     {{- include "loki-stack.labels" . | nindent 4 }}
   annotations:
     helm.sh/resource-policy: keep
-
-{{/* ClusterRole: collect-application-logs */}}
----
-apiVersion: rbac.authorization.k8s.io/v1
-kind: ClusterRole
-metadata:
-  name: collect-application-logs
-  labels:
-    {{- include "loki-stack.labels" . | nindent 4 }}
-  annotations:
-    helm.sh/resource-policy: keep
-rules:
-- apiGroups:
-  - logging.openshift.io
-  - observability.openshift.io
-  resourceNames:
-  - application
-  resources:
-  - logs
-  verbs:
-  - collect
-
-{{/* ClusterRole: collect-infrastructure-logs */}}
----
-apiVersion: rbac.authorization.k8s.io/v1
-kind: ClusterRole
-metadata:
-  name: collect-infrastructure-logs
-  labels:
-    {{- include "loki-stack.labels" . | nindent 4 }}
-  annotations:
-    helm.sh/resource-policy: keep
-rules:
-- apiGroups:
-  - logging.openshift.io
-  - observability.openshift.io
-  resourceNames:
-  - infrastructure
-  resources:
-  - logs
-  verbs:
-  - collect
-
-{{/* ClusterRole: collect-audit-logs */}}
----
-apiVersion: rbac.authorization.k8s.io/v1
-kind: ClusterRole
-metadata:
-  name: collect-audit-logs
-  labels:
-    {{- include "loki-stack.labels" . | nindent 4 }}
-  annotations:
-    helm.sh/resource-policy: keep
-rules:
-- apiGroups:
-  - logging.openshift.io
-  - observability.openshift.io
-  resourceNames:
-  - audit
-  resources:
-  - logs
-  verbs:
-  - collect
-
-{{/* ClusterRole: logging-collector-logs-writer */}}
----
-apiVersion: rbac.authorization.k8s.io/v1
-kind: ClusterRole
-metadata:
-  name: logging-collector-logs-writer
-  labels:
-    {{- include "loki-stack.labels" . | nindent 4 }}
-  annotations:
-    helm.sh/resource-policy: keep
-rules:
-- apiGroups: ["loki.grafana.com"]
-  resources: ["application", "infrastructure", "audit"]
-  verbs: ["create"]
 
 {{/* ClusterRoleBinding: collect-application-logs */}}
 ---


### PR DESCRIPTION
## Summary

- Remove 4 collector ClusterRole definitions from the loki-stack Helm chart (`collector-rbac.yaml`) — these are always provided by the cluster-logging operator via OLM, so the chart should not create them
- Fix error swallowing in 4 Helm install targets (`install-loki`, `install-observability` tempo/otel, `install-minio`) by changing `;` to `&&` so failures propagate and Make stops immediately
- Restore `RHOAI_VERSION` default to `2` (corrupted to `5.0.0` by the version-bump workflow bug addressed in #278)

## Root cause

On a clean cluster, `install-operators` installs the cluster-logging operator via OLM, which creates the 4 collector ClusterRoles with OLM ownership metadata. When `install-loki` runs afterward, Helm tries to create the same ClusterRoles and fails because they lack Helm ownership labels.

This was masked before PR #277 because `cleanup-loki-clusterroles` unconditionally deleted ClusterRoles before each install. PR #277 correctly stopped deleting them but exposed the underlying duplication.

## What changed

| File | Change |
|------|--------|
| `deploy/helm/observability/loki/templates/collector-rbac.yaml` | Removed 4 ClusterRole definitions; kept ServiceAccount and 4 ClusterRoleBindings |
| `Makefile` | Fixed `;` → `&&` in 4 Helm install targets; restored `RHOAI_VERSION ?= 2` |

## How it works

The ClusterRoleBindings still reference the same ClusterRole names — the only difference is that ClusterRole lifecycle is owned by OLM, not Helm. On fresh install, Helm creates the ServiceAccount and ClusterRoleBindings, which bind to the OLM-provided ClusterRoles.

## Test plan

Tested on two clusters (GPU + non-GPU) across both install paths:

- [x] Fresh `make install` on clean cluster — no ClusterRole conflict
- [x] Uninstall + re-install cycle — no conflicts on re-install
- [x] Operator-based install (`AIObservabilitySummarizer` CR) — no conflicts
- [x] ClusterLogForwarder collector starts successfully (not stuck in InProgress)
- [x] Helm failure propagation verified — build stops immediately on error
- [x] `RHOAI_VERSION` correctly defaults to `2`
- [x] Sanity test passed on both install paths

[Detailed analysis](https://gist.github.com/sgahlot/f69d017339ee6ea7249b813622d88f75)
