### PR TITLE
fix: remove RHOAI_VERSION default to prevent version-bump corruption

### DIFF
--- a/.github/workflows/update-versions.yml
+++ b/.github/workflows/update-versions.yml
@@ -81,9 +81,11 @@ jobs:
           fi
 
       - name: Update Makefile version
+        # NOTE: Anchor with ^ to match only the VERSION line, not any other
+        # variable whose name ends in VERSION.
         run: |
           if [ -f "Makefile" ]; then
-            sed -i 's|VERSION ?= .*|VERSION ?= '"${{ inputs.version }}"'|' Makefile
+            sed -i 's|^VERSION ?= .*|VERSION ?= '"${{ inputs.version }}"'|' Makefile
             echo "Updated Makefile"
           fi
 

--- a/Makefile
+++ b/Makefile
@@ -18,7 +18,6 @@ VERSION ?= 5.0.1
 PLATFORM ?= linux/amd64
 DEV_MODE ?= false
 USE_LLAMA_STACK_OPERATOR ?= false
-RHOAI_VERSION ?= 5.0.1
 
 # GPU Metrics Discovery - custom prefix overrides (comma-separated, additive)
 GPU_PREFIX_NVIDIA ?=
@@ -123,13 +122,16 @@ OPERATOR_MANAGER_SCRIPT := scripts/operator-manager.sh
 # Auto-detect RHOAI version from the cluster when not explicitly set on the command line.
 # Prevents the footgun of deploying on RHOAI 3.x with RHOAI_VERSION=2 defaults, which
 # would install logging/loki operators on stable-6.3 channels instead of stable-6.4.
-# $(origin RHOAI_VERSION) is "file" when set via ?= above, "command line" when explicit.
-ifeq ($(origin RHOAI_VERSION),file)
+# RHOAI_VERSION is NOT declared with ?= to avoid corruption by the version-bump workflow.
+# $(origin RHOAI_VERSION) is "undefined" when not set, "command line" when explicit.
+ifneq ($(origin RHOAI_VERSION),command line)
   _RHOAI_CSV := $(shell oc get csv -n redhat-ods-operator -l operators.coreos.com/rhods-operator.redhat-ods-operator \
     -o jsonpath='{.items[0].spec.version}' 2>/dev/null)
   ifneq ($(findstring 3.,$(_RHOAI_CSV)),)
     $(info ℹ️  Auto-detected RHOAI 3.x ($(_RHOAI_CSV)) — setting RHOAI_VERSION=3)
     RHOAI_VERSION := 3
+  else
+    RHOAI_VERSION := 2
   endif
 endif
 


### PR DESCRIPTION
## Summary
- Removed `RHOAI_VERSION ?=` from the Makefile entirely — the auto-detection block already derives the correct value from the cluster's RHOAI operator CSV, with a fallback to `2` when no RHOAI 3.x is detected
- Changed the auto-detection guard from `ifeq ($(origin RHOAI_VERSION),file)` to `ifneq ($(origin RHOAI_VERSION),command line)` so it triggers when the variable is undefined (not just when set via `?=`)
- Cherry-picked the `^` anchor fix from main (PR #278) into the `dev` branch's `update-versions.yml`, since push-triggered workflows use the branch's own workflow files

## Context

After PR #278 merged to `main`, the version-bump workflow on `dev` still corrupted `RHOAI_VERSION` because `dev` had the unfixed `update-versions.yml`. This two-part fix eliminates the attack surface entirely:

1. **No `RHOAI_VERSION ?=` line** → nothing for sed to corrupt
2. **`^` anchor on `VERSION` sed** → prevents future collateral matches

## Test plan
- [ ] Fresh install on clean cluster: `make install NAMESPACE=ai-observability RHOAI_VERSION=3 RAG_ENABLED=false`
- [ ] Verify auto-detection works when `RHOAI_VERSION` is not passed on CLI
- [ ] Verify explicit `RHOAI_VERSION=3` on CLI still overrides auto-detection
- [ ] Verify version-bump workflow no longer corrupts `RHOAI_VERSION` on push to dev
- [ ] Verify `make install` with `RHOAI_VERSION=2` (explicit) still works on RHOAI 2.x clusters

🤖 Generated with [Claude Code](https://claude.com/claude-code)