### PR TITLE
feat: dynamically detect logging/loki operator channels from cluster catalog

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -194,13 +194,14 @@ ifneq ($(LOKI_CHANNEL),)
   $(info ℹ️  Loki operator: channel=$(LOKI_CHANNEL), csv=$(LOKI_STARTING_CSV))
 endif
 
-# Guard macro: fails with actionable error when operator channel was not detected.
-# Called at recipe time by install targets that need the channel, so non-cluster
-# targets (test, build, help) are not affected.
+# Guard macro: fails with actionable error when operator channel or starting CSV
+# was not detected.  Called at recipe time by install targets that need them, so
+# non-cluster targets (test, build, help) are not affected.
 define _require_operator_channel
-	@if [ -z "$(LOGGING_CHANNEL)" ] || [ -z "$(LOKI_CHANNEL)" ]; then \
+	@if [ -z "$(LOGGING_CHANNEL)" ] || [ -z "$(LOKI_CHANNEL)" ] || \
+	    [ -z "$(LOGGING_STARTING_CSV)" ] || [ -z "$(LOKI_STARTING_CSV)" ]; then \
 		echo ""; \
-		echo "🛑 Could not detect logging/loki operator channel from the redhat-operators catalog."; \
+		echo "🛑 Could not detect logging/loki operator channel or starting CSV from the redhat-operators catalog."; \
 		echo "   Verify the cluster is reachable and the catalog is healthy:"; \
 		echo "     - oc get catalogsource redhat-operators -n openshift-marketplace"; \
 		echo "Exiting!!!"; \

--- a/Makefile
+++ b/Makefile
@@ -171,20 +171,11 @@ endif
 
 # Logging/Loki operator channel and starting CSV.
 # Auto-detected from the cluster's redhat-operators catalog (defaultChannel + currentCSV).
-# Fails if the cluster is unreachable — no hardcoded fallback to avoid installing untested versions.
+# No hardcoded fallback — install targets fail fast if detection fails.
 # NOTE: Must query with -l catalog=redhat-operators because loki-operator also exists
 # in community-operators (with only an 'alpha' channel).
 LOGGING_LOKI_CHANNEL := $(shell oc get packagemanifest -l catalog=redhat-operators \
     -o jsonpath='{range .items[?(@.metadata.name=="cluster-logging")]}{.status.defaultChannel}{end}' 2>/dev/null)
-ifeq ($(LOGGING_LOKI_CHANNEL),)
-  $(info )
-  $(info  🛑 Could not detect logging/loki operator channel from the redhat-operators catalog.)
-  $(info     Verify the cluster is reachable and the catalog is healthy:)
-  $(info       - oc get catalogsource redhat-operators -n openshift-marketplace)
-  $(info  Exiting!!!)
-  $(info )
-  $(error Aborting)
-endif
 
 LOGGING_STARTING_CSV := $(shell oc get packagemanifest -l catalog=redhat-operators \
     -o jsonpath='{range .items[?(@.metadata.name=="cluster-logging")].status.channels[?(@.name=="$(LOGGING_LOKI_CHANNEL)")]}{.currentCSV}{end}' 2>/dev/null)
@@ -195,6 +186,21 @@ LOKI_STARTING_CSV := $(shell oc get packagemanifest -l catalog=redhat-operators 
 ifneq ($(LOGGING_LOKI_CHANNEL),)
   $(info ℹ️  Operator channels: $(LOGGING_LOKI_CHANNEL) (logging=$(LOGGING_STARTING_CSV), loki=$(LOKI_STARTING_CSV)))
 endif
+
+# Guard macro: fails with actionable error when operator channel was not detected.
+# Called at recipe time by install targets that need the channel, so non-cluster
+# targets (test, build, help) are not affected.
+define _require_operator_channel
+	@if [ -z "$(LOGGING_LOKI_CHANNEL)" ]; then \
+		echo ""; \
+		echo "🛑 Could not detect logging/loki operator channel from the redhat-operators catalog."; \
+		echo "   Verify the cluster is reachable and the catalog is healthy:"; \
+		echo "     - oc get catalogsource redhat-operators -n openshift-marketplace"; \
+		echo "Exiting!!!"; \
+		echo ""; \
+		exit 1; \
+	fi
+endef
 
 # Validate: LlamaStack operator requires RHOAI 3.x (operator v0.3.0 on RHOAI 2.x is not supported)
 ifeq ($(USE_LLAMA_STACK_OPERATOR),true)
@@ -1619,12 +1625,14 @@ install-tempo-operator:
 # Install OpenShift Logging Operator
 .PHONY: install-logging-operator
 install-logging-operator:
+	$(call _require_operator_channel)
 	@echo ""
 	@CHANNEL=$(LOGGING_LOKI_CHANNEL) STARTING_CSV=$(LOGGING_STARTING_CSV) $(OPERATOR_MANAGER_SCRIPT) -i logging -n openshift-logging
 
 # Install Loki Operator
 .PHONY: install-loki-operator
 install-loki-operator:
+	$(call _require_operator_channel)
 	@echo ""
 	@CHANNEL=$(LOGGING_LOKI_CHANNEL) STARTING_CSV=$(LOKI_STARTING_CSV) $(OPERATOR_MANAGER_SCRIPT) -i loki -n openshift-operators-redhat
 

--- a/Makefile
+++ b/Makefile
@@ -169,29 +169,36 @@ else
   LLAMA_STACK_SVC_NAME := llamastack
 endif
 
-# Logging/Loki operator channel and starting CSV.
-# Auto-detected from the cluster's redhat-operators catalog (defaultChannel + currentCSV).
+# Logging/Loki operator channels and starting CSVs.
+# Auto-detected independently from the cluster's redhat-operators catalog.
 # No hardcoded fallback — install targets fail fast if detection fails.
 # NOTE: Must query with -l catalog=redhat-operators because loki-operator also exists
 # in community-operators (with only an 'alpha' channel).
-LOGGING_LOKI_CHANNEL := $(shell oc get packagemanifest -l catalog=redhat-operators \
+
+# Logging operator channel + CSV
+LOGGING_CHANNEL := $(shell oc get packagemanifest -l catalog=redhat-operators \
     -o jsonpath='{range .items[?(@.metadata.name=="cluster-logging")]}{.status.defaultChannel}{end}' 2>/dev/null)
-
 LOGGING_STARTING_CSV := $(shell oc get packagemanifest -l catalog=redhat-operators \
-    -o jsonpath='{range .items[?(@.metadata.name=="cluster-logging")].status.channels[?(@.name=="$(LOGGING_LOKI_CHANNEL)")]}{.currentCSV}{end}' 2>/dev/null)
+    -o jsonpath='{range .items[?(@.metadata.name=="cluster-logging")].status.channels[?(@.name=="$(LOGGING_CHANNEL)")]}{.currentCSV}{end}' 2>/dev/null)
 
+# Loki operator channel + CSV (queried independently — channels may diverge from logging)
+LOKI_CHANNEL := $(shell oc get packagemanifest -l catalog=redhat-operators \
+    -o jsonpath='{range .items[?(@.metadata.name=="loki-operator")]}{.status.defaultChannel}{end}' 2>/dev/null)
 LOKI_STARTING_CSV := $(shell oc get packagemanifest -l catalog=redhat-operators \
-    -o jsonpath='{range .items[?(@.metadata.name=="loki-operator")].status.channels[?(@.name=="$(LOGGING_LOKI_CHANNEL)")]}{.currentCSV}{end}' 2>/dev/null)
+    -o jsonpath='{range .items[?(@.metadata.name=="loki-operator")].status.channels[?(@.name=="$(LOKI_CHANNEL)")]}{.currentCSV}{end}' 2>/dev/null)
 
-ifneq ($(LOGGING_LOKI_CHANNEL),)
-  $(info ℹ️  Operator channels: $(LOGGING_LOKI_CHANNEL) (logging=$(LOGGING_STARTING_CSV), loki=$(LOKI_STARTING_CSV)))
+ifneq ($(LOGGING_CHANNEL),)
+  $(info ℹ️  Logging operator: channel=$(LOGGING_CHANNEL), csv=$(LOGGING_STARTING_CSV))
+endif
+ifneq ($(LOKI_CHANNEL),)
+  $(info ℹ️  Loki operator: channel=$(LOKI_CHANNEL), csv=$(LOKI_STARTING_CSV))
 endif
 
 # Guard macro: fails with actionable error when operator channel was not detected.
 # Called at recipe time by install targets that need the channel, so non-cluster
 # targets (test, build, help) are not affected.
 define _require_operator_channel
-	@if [ -z "$(LOGGING_LOKI_CHANNEL)" ]; then \
+	@if [ -z "$(LOGGING_CHANNEL)" ] || [ -z "$(LOKI_CHANNEL)" ]; then \
 		echo ""; \
 		echo "🛑 Could not detect logging/loki operator channel from the redhat-operators catalog."; \
 		echo "   Verify the cluster is reachable and the catalog is healthy:"; \
@@ -1627,14 +1634,14 @@ install-tempo-operator:
 install-logging-operator:
 	$(call _require_operator_channel)
 	@echo ""
-	@CHANNEL=$(LOGGING_LOKI_CHANNEL) STARTING_CSV=$(LOGGING_STARTING_CSV) $(OPERATOR_MANAGER_SCRIPT) -i logging -n openshift-logging
+	@CHANNEL=$(LOGGING_CHANNEL) STARTING_CSV=$(LOGGING_STARTING_CSV) $(OPERATOR_MANAGER_SCRIPT) -i logging -n openshift-logging
 
 # Install Loki Operator
 .PHONY: install-loki-operator
 install-loki-operator:
 	$(call _require_operator_channel)
 	@echo ""
-	@CHANNEL=$(LOGGING_LOKI_CHANNEL) STARTING_CSV=$(LOKI_STARTING_CSV) $(OPERATOR_MANAGER_SCRIPT) -i loki -n openshift-operators-redhat
+	@CHANNEL=$(LOKI_CHANNEL) STARTING_CSV=$(LOKI_STARTING_CSV) $(OPERATOR_MANAGER_SCRIPT) -i loki -n openshift-operators-redhat
 
 # Verify all required operators are installed and ready
 .PHONY: verify-operators-ready

--- a/Makefile
+++ b/Makefile
@@ -120,8 +120,6 @@ DEFAULT_LLM_PORT_AND_PATH := :8080/v1
 OPERATOR_MANAGER_SCRIPT := scripts/operator-manager.sh
 
 # Auto-detect RHOAI version from the cluster when not explicitly set on the command line.
-# Prevents the footgun of deploying on RHOAI 3.x with RHOAI_VERSION=2 defaults, which
-# would install logging/loki operators on stable-6.3 channels instead of stable-6.4.
 # RHOAI_VERSION is NOT declared with ?= to avoid corruption by the version-bump workflow.
 # $(origin RHOAI_VERSION) is "undefined" when not set, "command line" when explicit.
 ifneq ($(origin RHOAI_VERSION),command line)
@@ -171,15 +169,31 @@ else
   LLAMA_STACK_SVC_NAME := llamastack
 endif
 
-# Logging/Loki operator channel and starting CSV: RHOAI 3.x uses stable-6.4, RHOAI 2.x uses stable-6.3
-ifeq ($(RHOAI_VERSION),3)
-  LOGGING_LOKI_CHANNEL := stable-6.4
-  LOGGING_STARTING_CSV := cluster-logging.v6.4.3
-  LOKI_STARTING_CSV := loki-operator.v6.4.3
-else
-  LOGGING_LOKI_CHANNEL := stable-6.3
-  LOGGING_STARTING_CSV := cluster-logging.v6.3.4
-  LOKI_STARTING_CSV := loki-operator.v6.3.4
+# Logging/Loki operator channel and starting CSV.
+# Auto-detected from the cluster's redhat-operators catalog (defaultChannel + currentCSV).
+# Fails if the cluster is unreachable — no hardcoded fallback to avoid installing untested versions.
+# NOTE: Must query with -l catalog=redhat-operators because loki-operator also exists
+# in community-operators (with only an 'alpha' channel).
+LOGGING_LOKI_CHANNEL := $(shell oc get packagemanifest -l catalog=redhat-operators \
+    -o jsonpath='{range .items[?(@.metadata.name=="cluster-logging")]}{.status.defaultChannel}{end}' 2>/dev/null)
+ifeq ($(LOGGING_LOKI_CHANNEL),)
+  $(info )
+  $(info  🛑 Could not detect logging/loki operator channel from the redhat-operators catalog.)
+  $(info     Verify the cluster is reachable and the catalog is healthy:)
+  $(info       - oc get catalogsource redhat-operators -n openshift-marketplace)
+  $(info  Exiting!!!)
+  $(info )
+  $(error Aborting)
+endif
+
+LOGGING_STARTING_CSV := $(shell oc get packagemanifest -l catalog=redhat-operators \
+    -o jsonpath='{range .items[?(@.metadata.name=="cluster-logging")].status.channels[?(@.name=="$(LOGGING_LOKI_CHANNEL)")]}{.currentCSV}{end}' 2>/dev/null)
+
+LOKI_STARTING_CSV := $(shell oc get packagemanifest -l catalog=redhat-operators \
+    -o jsonpath='{range .items[?(@.metadata.name=="loki-operator")].status.channels[?(@.name=="$(LOGGING_LOKI_CHANNEL)")]}{.currentCSV}{end}' 2>/dev/null)
+
+ifneq ($(LOGGING_LOKI_CHANNEL),)
+  $(info ℹ️  Operator channels: $(LOGGING_LOKI_CHANNEL) (logging=$(LOGGING_STARTING_CSV), loki=$(LOKI_STARTING_CSV)))
 endif
 
 # Validate: LlamaStack operator requires RHOAI 3.x (operator v0.3.0 on RHOAI 2.x is not supported)


### PR DESCRIPTION
## Summary

- Replace hardcoded channel mapping (RHOAI 3.x → `stable-6.4`, 2.x → `stable-6.3`) with dynamic detection from the cluster's `redhat-operators` PackageManifest
- Query `defaultChannel` and `currentCSV` at Makefile parse time — always uses what the cluster actually has available
- Fail fast with actionable error if the cluster is unreachable or catalog is unhealthy
- Remove RHOAI_VERSION dependency from channel selection entirely

## Problem

On clusters where `stable-6.3` has been removed from the catalog, `make install` fails silently — OLM creates a Subscription referencing a non-existent channel, no InstallPlan is ever generated, and the install hangs indefinitely:

```
subscription.operators.coreos.com/cluster-logging created
📋 Manual approval required; target CSV: cluster-logging.v6.3.4
⏳ Waiting for InstallPlan to be created (attempt 1/60)...
⏳ Waiting for InstallPlan to be created (attempt 2/60)...
```

The underlying OLM error: `no operators found in channel stable-6.3 of package cluster-logging`

## Key detail: loki-operator catalog ambiguity

`loki-operator` exists in **two** catalogs:
- `community-operators` — only has an `alpha` channel
- `redhat-operators` — has `stable-6.4`, `stable-6.5`, etc.

The default `oc get packagemanifest loki-operator` returns the community one. The fix explicitly queries with `-l catalog=redhat-operators` to get the correct channels.

## Test results

Tested on RHOAI 2.x cluster (2.25.4) where `stable-6.3` was removed:

```
ℹ️  Operator channels: stable-6.5 (logging=cluster-logging.v6.5.0, loki=loki-operator.v6.5.0)
```

Full install succeeded — all operators installed on `stable-6.5`, Loki stack deployed, all app components running.

Cluster-unreachable case:
```
🛑 Could not detect logging/loki operator channel from the redhat-operators catalog.
   Verify the cluster is reachable and the catalog is healthy:
     - oc get catalogsource redhat-operators -n openshift-marketplace
Exiting!!!
```

## Test plan
- [x] Fresh install on RHOAI 2.x cluster with `stable-6.3` removed — detects `stable-6.5`, installs successfully
- [x] All operators installed: cluster-logging v6.5.0, loki v6.5.0, COO, OpenTelemetry, Tempo
- [x] All app pods running: predictor (2/2), llamastack, mcp-server, console-plugin, pgvector
- [x] Cluster-unreachable simulation — fails fast with actionable error
- [ ] Fresh install on RHOAI 3.x cluster — verify dynamic detection works