### PR TITLE
fix: pass target_branch to build-operator-images to avoid pushing to main

### DIFF
--- a/.github/workflows/build-operator-images.yml
+++ b/.github/workflows/build-operator-images.yml
@@ -21,6 +21,11 @@ on:
         required: false
         default: true
         type: boolean
+      target_branch:
+        description: 'Branch to commit and push operator manifest changes to'
+        required: false
+        default: ''
+        type: string
 
 permissions:
   contents: write
@@ -32,6 +37,8 @@ jobs:
     steps:
       - name: Checkout repository
         uses: actions/checkout@v5
+        with:
+          ref: ${{ inputs.target_branch != '' && inputs.target_branch || github.ref_name }}
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
@@ -93,8 +100,8 @@ jobs:
       - name: Commit and push operator manifest changes
         if: ${{ inputs.push_changes }}
         run: |
-          # Add all files updated by make bundle and catalog image update
-          # Use git add -A to catch any files created by bundle generation
+          PUSH_BRANCH="${{ inputs.target_branch != '' && inputs.target_branch || github.ref_name }}"
+
           git add deploy/operator/catalog-source.yaml
           git add deploy/operator/bundle/
           git add deploy/operator/config/manager/kustomization.yaml
@@ -113,39 +120,25 @@ jobs:
           EOF
           )"
 
-            # Stash any remaining unstaged changes before pulling
-            if ! git diff --quiet || ! git diff --cached --quiet; then
-              echo "Stashing unstaged changes..."
-              git stash push -u -m "temp stash before pull"
-              STASHED=true
-            else
-              STASHED=false
-            fi
-
-            # Pull latest changes before pushing (handles race conditions)
-            echo "Pulling latest changes..."
-            git pull --rebase origin ${GITHUB_REF#refs/heads/}
-
-            # Pop stash if we stashed
-            if [ "$STASHED" = "true" ]; then
-              echo "Restoring stashed changes..."
-              git stash pop || true
-            fi
-
-            # Push with retry logic
+            # Push with retry logic; stash/pop unstaged changes around each pull
             echo "Pushing changes..."
             max_retries=3
             retry_count=0
             while [ $retry_count -lt $max_retries ]; do
-              if git push origin ${GITHUB_REF#refs/heads/}; then
+              if git push origin "$PUSH_BRANCH"; then
                 echo "✅ Successfully pushed changes"
                 break
               else
                 retry_count=$((retry_count + 1))
                 if [ $retry_count -lt $max_retries ]; then
                   echo "Push failed, retrying ($retry_count/$max_retries)..."
-                  git pull --rebase origin ${GITHUB_REF#refs/heads/}
-                  sleep 2
+                  if ! git diff --quiet || ! git diff --cached --quiet; then
+                    git stash push -u -m "temp stash before pull"
+                    git pull --rebase origin "$PUSH_BRANCH"
+                    git stash pop || true
+                  else
+                    git pull --rebase origin "$PUSH_BRANCH"
+                  fi
                 else
                   echo "❌ Failed to push after $max_retries attempts"
                   exit 1

--- a/.github/workflows/prepare-release.yml
+++ b/.github/workflows/prepare-release.yml
@@ -194,6 +194,7 @@ jobs:
       registry: quay.io
       org: ecosystem-appeng
       push_changes: true
+      target_branch: ${{ inputs.target_branch }}
     secrets: inherit
 
   create-pr:


### PR DESCRIPTION
## Summary
Problem: In `Prepare Release` workflow, with custom version 3.1.0 and target branch `dev`, the workflow fails in building operator image:
```
[main e40926b] chore: update operator manifests to v3.1.0
 3 files changed, 6 insertions(+), 6 deletions(-)
Stashing unstaged changes...
Saved working directory and index state On main: temp stash before pull
Pulling latest changes...
From https://github.com/rh-ai-quickstart/ai-observability-summarizer
 * branch            main       -> FETCH_HEAD
Current branch main is up to date.
Restoring stashed changes...
On branch main
Your branch is ahead of 'origin/main' by 1 commit.
  (use "git push" to publish your local commits)
Changes not staged for commit:
  (use "git add <file>..." to update what will be committed)
  (use "git restore <file>..." to discard changes in working directory)
	modified:   deploy/helm/aiobs-stack/values.yaml
	modified:   deploy/helm/mcp-server/values.yaml
	modified:   deploy/helm/openshift-console-plugin/values.yaml
	modified:   deploy/helm/react-ui-app/values.yaml
no changes added to commit (use "git add" and/or "git commit -a")
Dropped refs/stash@{0} (d1313ecb9360fd7506cf59529f4fb6339e270487)
Pushing changes...
remote: error: GH013: Repository rule violations found for refs/heads/main.        
remote: Review all repository rules at https://github.com/rh-ai-quickstart/ai-observability-summarizer/rules?ref=refs%2Fheads%2Fmain        
remote: 
remote: - Changes must be made through a pull request.        
remote: 
To https://github.com/rh-ai-quickstart/ai-observability-summarizer
 ! [remote rejected] main -> main (push declined due to repository rule violations)
error: failed to push some refs to 'https://github.com/rh-ai-quickstart/ai-observability-summarizer'
Push failed, retrying (1/3)...
error: cannot pull with rebase: You have unstaged changes.
error: Please commit or stash them.
Error: Process completed with exit code 128.
```
Solution:
- Add `target_branch` input to `build-operator-images.yml` so it checks out and pushes to the correct branch (e.g. `dev`) instead of `GITHUB_REF` (which resolves to `main` when triggered via `workflow_dispatch`)
- Pass `target_branch` from `prepare-release.yml` down to the reusable workflow
- Fix retry loop to stash unstaged changes before each `git pull --rebase`, preventing the "cannot pull with rebase: You have unstaged changes" error on push retries

## Root cause

When `prepare-release` was run with `target_branch: dev`, the reusable `build-operator-images` workflow had no knowledge of the target branch. It used `${GITHUB_REF#refs/heads/}` for both checkout and push, which resolved to `main` (the branch from which `workflow_dispatch` was triggered). Pushing directly to `main` failed due to branch protection rules requiring PRs.

## Test plan

- [ ] Run `prepare-release` workflow with `target_branch: dev` — operator manifest commit should land on `dev`, not `main`
- [ ] Verify no "push declined due to repository rule violations" error in the Build and Push operator images step

🤖 Generated with [Claude Code](https://claude.com/claude-code)